### PR TITLE
Added support for https (including simultaneous http and https)

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -21,58 +21,58 @@
 -export([start/1, stop/0, loop/1]).
 
 start([{http, HttpOptions}, {common, CommonOptions}]) ->
-	start([{http, HttpOptions}, {https, undefined}, {common, CommonOptions}]);
+    start([{http, HttpOptions}, {https, undefined}, {common, CommonOptions}]);
 start([{https, HttpsOptions}, {common, CommonOptions}]) ->
-	start([{http, undefined}, {https, HttpsOptions}, {common, CommonOptions}]);
+    start([{http, undefined}, {https, HttpsOptions}, {common, CommonOptions}]);
 start([{http, HttpOptions}, {https, HttpsOptions}, {common, CommonOptions}]) ->
     {DispatchList, Options1} = get_option(dispatch, CommonOptions),
     {ErrorHandler0, Options2} = get_option(error_handler, Options1),
     {EnablePerfLog, Options3} = get_option(enable_perf_logger, Options2),
     ErrorHandler = 
-		case ErrorHandler0 of
-		    undefined ->
-				webmachine_error_handler;
-		    EH -> EH
-		end,
+        case ErrorHandler0 of
+            undefined ->
+                webmachine_error_handler;
+            EH -> EH
+        end,
     {LogDir, _} = get_option(log_dir, Options3),
     webmachine_sup:start_logger(LogDir),
     case EnablePerfLog of
-		true ->
-		    application:set_env(webmachine, enable_perf_logger, true),
-		    webmachine_sup:start_perf_logger(LogDir);
-		_ ->
-		    ignore
+        true ->
+            application:set_env(webmachine, enable_perf_logger, true),
+            webmachine_sup:start_perf_logger(LogDir);
+        _ ->
+            ignore
     end,
     application:set_env(webmachine, dispatch_list, DispatchList),
     application:set_env(webmachine, error_handler, ErrorHandler),
 
-	Res = case HttpOptions of
-		undefined -> undefined;
-		_ ->
-			mochiweb_http:start([{name, ?MODULE}, {loop, fun loop/1} | HttpOptions])
-	end,
-	case HttpsOptions of
-		undefined -> Res;
-		_ ->
-			mochiweb_http:start([{name, https_name()}, {loop, fun loop/1} | HttpsOptions])
-	end;
+    Res = case HttpOptions of
+        undefined -> undefined;
+        _ ->
+            mochiweb_http:start([{name, ?MODULE}, {loop, fun loop/1} | HttpOptions])
+    end,
+    case HttpsOptions of
+        undefined -> Res;
+        _ ->
+            mochiweb_http:start([{name, https_name()}, {loop, fun loop/1} | HttpsOptions])
+    end;
 start(Options) ->
-	{DispatchList, Options1} = get_option(dispatch, Options),
+    {DispatchList, Options1} = get_option(dispatch, Options),
     {ErrorHandler0, Options2} = get_option(error_handler, Options1),
     {EnablePerfLog, Options3} = get_option(enable_perf_logger, Options2),
     {LogDir, Options4} = get_option(log_dir, Options3),
 
-	CommonOptions = [
-		{dispatch, DispatchList},
-		{error_handler, ErrorHandler0},
-		{enable_perf_logger, EnablePerfLog},
-		{log_dir, LogDir}
-	],
-	start([{http, Options4}, {common, CommonOptions}]).
+    CommonOptions = [
+        {dispatch, DispatchList},
+        {error_handler, ErrorHandler0},
+        {enable_perf_logger, EnablePerfLog},
+        {log_dir, LogDir}
+    ],
+    start([{http, Options4}, {common, CommonOptions}]).
 
 stop() ->
     mochiweb_http:stop(?MODULE),
-	mochiweb_http:stop(https_name()).
+    mochiweb_http:stop(https_name()).
 
 https_name() -> list_to_atom(atom_to_list(?MODULE) ++ "_https").
 
@@ -87,14 +87,14 @@ loop(MochiReq) ->
     case webmachine_dispatcher:dispatch(Host, Path, DispatchList) of
         {no_dispatch_match, _UnmatchedHost, _UnmatchedPathTokens} ->
             {ok, ErrorHandler} = application:get_env(webmachine, error_handler),
-	    {ErrorHTML,ReqState1} = 
+        {ErrorHTML,ReqState1} =
                 ErrorHandler:render_error(404, Req, {none, none, []}),
             Req1 = {webmachine_request,ReqState1},
-	    {ok,ReqState2} = Req1:append_to_response_body(ErrorHTML),
+        {ok,ReqState2} = Req1:append_to_response_body(ErrorHTML),
             Req2 = {webmachine_request,ReqState2},
-	    {ok,ReqState3} = Req2:send_response(404),
+        {ok,ReqState3} = Req2:send_response(404),
             Req3 = {webmachine_request,ReqState3},
-	    {LogData,_ReqState4} = Req3:log_data(),
+        {LogData,_ReqState4} = Req3:log_data(),
             case application:get_env(webmachine,webmachine_logger_module) of
                 {ok, LogModule} ->
                     spawn(LogModule, log_access, [LogData]);

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -91,8 +91,11 @@ trim_state() ->
 get_peer() ->
     case ReqState#wm_reqstate.peer of
 	undefined ->
-            Socket = ReqState#wm_reqstate.socket,
-	    Peer = case inet:peername(Socket) of 
+        PeerName = case ReqState#wm_reqstate.socket of
+			{ssl,SslSocket} -> ssl:peername(SslSocket);
+			_ -> inet:peername(ReqState#wm_reqstate.socket)
+		end,
+	    Peer = case PeerName of
 		{ok, {Addr={10, _, _, _}, _Port}} ->
 		    case get_header_value("x-forwarded-for") of
 			{undefined, _} ->
@@ -109,8 +112,8 @@ get_peer() ->
 		    end;
 		{ok, {Addr, _Port}} ->
 		    inet_parse:ntoa(Addr)
-            end,
-            NewReqState = ReqState#wm_reqstate{peer=Peer},
+        end,
+        NewReqState = ReqState#wm_reqstate{peer=Peer},
 	    {Peer, NewReqState};
 	_ ->
 	    {ReqState#wm_reqstate.peer, ReqState}

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -29,51 +29,51 @@
          trim_state/0,
          get_reqdata/0,
          set_reqdata/1,
-	 socket/0,
-	 method/0,
-	 version/0,
+     socket/0,
+     method/0,
+     version/0,
          disp_path/0,
-	 path/0,
-	 raw_path/0,
+     path/0,
+     raw_path/0,
          get_req_header/1,
-	 req_headers/0,
-	 req_body/1,
-	 stream_req_body/1,
-	 headers/0,
-	 resp_headers/0,
-	 out_headers/0,
-	 get_out_header/1,
-	 has_out_header/1,
-	 peer/0,
-	 get_header_value/1,
-	 add_response_header/2,
-	 add_response_headers/1,
-	 remove_response_header/1,
-	 merge_response_headers/1,
-	 append_to_response_body/1,
-	 send_response/1,
-	 response_code/0,
-	 set_response_code/1,
+     req_headers/0,
+     req_body/1,
+     stream_req_body/1,
+     headers/0,
+     resp_headers/0,
+     out_headers/0,
+     get_out_header/1,
+     has_out_header/1,
+     peer/0,
+     get_header_value/1,
+     add_response_header/2,
+     add_response_headers/1,
+     remove_response_header/1,
+     merge_response_headers/1,
+     append_to_response_body/1,
+     send_response/1,
+     response_code/0,
+     set_response_code/1,
          set_resp_body/1,
-	 response_body/0,
-	 has_response_body/0,
+     response_body/0,
+     has_response_body/0,
          do_redirect/0,
          resp_redirect/0,
-	 set_metadata/2,
-	 get_metadata/1,
-	 get_path_info/0,
-	 get_path_info/1,
-	 load_dispatch_data/6,
-	 get_path_tokens/0,
-	 get_app_root/0,
-	 parse_cookie/0,
-	 get_cookie_value/1,
-	 parse_qs/0,
-	 get_qs_value/1,
-	 get_qs_value/2,
+     set_metadata/2,
+     get_metadata/1,
+     get_path_info/0,
+     get_path_info/1,
+     load_dispatch_data/6,
+     get_path_tokens/0,
+     get_app_root/0,
+     parse_cookie/0,
+     get_cookie_value/1,
+     parse_qs/0,
+     get_qs_value/1,
+     get_qs_value/2,
          range/0,
-	 log_data/0
-	 ]).
+     log_data/0
+     ]).
 
 -include("webmachine_logger.hrl").
 -include_lib("include/wm_reqstate.hrl").
@@ -90,33 +90,33 @@ trim_state() ->
 
 get_peer() ->
     case ReqState#wm_reqstate.peer of
-	undefined ->
+    undefined ->
         PeerName = case ReqState#wm_reqstate.socket of
-			{ssl,SslSocket} -> ssl:peername(SslSocket);
-			_ -> inet:peername(ReqState#wm_reqstate.socket)
-		end,
-	    Peer = case PeerName of
-		{ok, {Addr={10, _, _, _}, _Port}} ->
-		    case get_header_value("x-forwarded-for") of
-			{undefined, _} ->
-			    inet_parse:ntoa(Addr);
-			{Hosts, _} ->
-			    string:strip(lists:last(string:tokens(Hosts, ",")))
-		    end;
-		{ok, {{127, 0, 0, 1}, _Port}} ->
-		    case get_header_value("x-forwarded-for") of
-			{undefined, _} ->
-			    "127.0.0.1";
-			{Hosts, _} ->
-			    string:strip(lists:last(string:tokens(Hosts, ",")))
-		    end;
-		{ok, {Addr, _Port}} ->
-		    inet_parse:ntoa(Addr)
+            {ssl,SslSocket} -> ssl:peername(SslSocket);
+            _ -> inet:peername(ReqState#wm_reqstate.socket)
+        end,
+        Peer = case PeerName of
+        {ok, {Addr={10, _, _, _}, _Port}} ->
+            case get_header_value("x-forwarded-for") of
+            {undefined, _} ->
+                inet_parse:ntoa(Addr);
+            {Hosts, _} ->
+                string:strip(lists:last(string:tokens(Hosts, ",")))
+            end;
+        {ok, {{127, 0, 0, 1}, _Port}} ->
+            case get_header_value("x-forwarded-for") of
+            {undefined, _} ->
+                "127.0.0.1";
+            {Hosts, _} ->
+                string:strip(lists:last(string:tokens(Hosts, ",")))
+            end;
+        {ok, {Addr, _Port}} ->
+            inet_parse:ntoa(Addr)
         end,
         NewReqState = ReqState#wm_reqstate{peer=Peer},
-	    {Peer, NewReqState};
-	_ ->
-	    {ReqState#wm_reqstate.peer, ReqState}
+        {Peer, NewReqState};
+    _ ->
+        {ReqState#wm_reqstate.peer, ReqState}
     end.
 
 call(socket) -> {ReqState#wm_reqstate.socket,ReqState};
@@ -203,12 +203,12 @@ call(do_redirect) ->
            reqdata=wrq:do_redirect(true, ReqState#wm_reqstate.reqdata)}};
 call({send_response, Code}) ->
     {Reply, NewState} = 
-	case Code of
-	    200 ->
-		    send_ok_response();
-	    _ ->
-		    send_response(Code)
-	end,
+    case Code of
+        200 ->
+            send_ok_response();
+        _ ->
+            send_response(Code)
+    end,
     LogData = NewState#wm_reqstate.log_data,
     NewLogData = LogData#wm_log_data{finish_time=now()},
     {Reply, NewState#wm_reqstate{log_data=NewLogData}};
@@ -225,9 +225,9 @@ call(has_resp_body) ->
     {Reply, ReqState};
 call({get_metadata, Key}) ->
     Reply = case dict:find(Key, ReqState#wm_reqstate.metadata) of
-		{ok, Value} -> Value;
-		error -> undefined
-	    end,
+        {ok, Value} -> Value;
+        error -> undefined
+        end,
     {Reply, ReqState};
 call({set_metadata, Key, Value}) ->
     NewDict = dict:store(Key, Value, ReqState#wm_reqstate.metadata),
@@ -253,9 +253,9 @@ get_outheader_value(K) ->
 
 send(Socket, Data) ->
     case mochiweb_socket:send(Socket, iolist_to_binary(Data)) of
-	ok -> ok;
-	{error,closed} -> ok;
-	_ -> exit(normal)
+    ok -> ok;
+    {error,closed} -> ok;
+    _ -> exit(normal)
     end.
 
 send_stream_body(Socket, X) -> send_stream_body(Socket, X, 0).
@@ -297,23 +297,23 @@ send_ok_response() ->
     RD0 = ReqState#wm_reqstate.reqdata,
     {Range, State} = get_range(),
     case Range of
-	X when X =:= undefined; X =:= fail ->
-	    send_response(200);
-	Ranges ->
-	    {PartList, Size} = range_parts(RD0, Ranges),
-	    case PartList of
-		[] -> %% no valid ranges
-		    %% could be 416, for now we'll just return 200
-		    send_response(200);
-		PartList ->
-		    {RangeHeaders, RangeBody} = parts_to_body(PartList, Size),
-		    RespHdrsRD = wrq:set_resp_headers(
+    X when X =:= undefined; X =:= fail ->
+        send_response(200);
+    Ranges ->
+        {PartList, Size} = range_parts(RD0, Ranges),
+        case PartList of
+        [] -> %% no valid ranges
+            %% could be 416, for now we'll just return 200
+            send_response(200);
+        PartList ->
+            {RangeHeaders, RangeBody} = parts_to_body(PartList, Size),
+            RespHdrsRD = wrq:set_resp_headers(
                         [{"Accept-Ranges", "bytes"} | RangeHeaders], RD0),
                     RespBodyRD = wrq:set_resp_body(
                                    RangeBody, RespHdrsRD),
-		    NewState = State#wm_reqstate{reqdata=RespBodyRD},
-		    send_response(206, NewState)
-	    end
+            NewState = State#wm_reqstate{reqdata=RespBodyRD},
+            send_response(206, NewState)
+        end
     end.
 
 send_response(Code) -> send_response(Code,ReqState).
@@ -325,12 +325,12 @@ send_response(Code, PassedState=#wm_reqstate{reqdata=RD}) ->
         _ -> {Body0, iolist_size([Body0])}
     end,
     send(PassedState#wm_reqstate.socket,
-	 [make_version(wrq:version(RD)),
+     [make_version(wrq:version(RD)),
           make_code(Code), <<"\r\n">> | 
          make_headers(Code, Length, RD)]),
     FinalLength = case wrq:method(RD) of 
-	'HEAD' -> Length;
-	_ -> 
+    'HEAD' -> Length;
+    _ ->
             case Body of
                 {stream, Body2} ->
                     send_stream_body(PassedState#wm_reqstate.socket, Body2);
@@ -343,7 +343,7 @@ send_response(Code, PassedState=#wm_reqstate{reqdata=RD}) ->
     end,
     InitLogData = PassedState#wm_reqstate.log_data,
     FinalLogData = InitLogData#wm_log_data{response_code=Code,
-					   response_length=FinalLength},
+                       response_length=FinalLength},
     {ok, PassedState#wm_reqstate{reqdata=wrq:set_response_code(Code, RD),
                      log_data=FinalLogData}}.
 
@@ -385,12 +385,12 @@ read_whole_stream({Hunk,Next}, Acc0, MaxRecvBody, SizeAcc) ->
 recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
     put(mochiweb_request_recv, true),
     case get_header_value("expect") of
-	{"100-continue", _} ->
-	    send(PassedState#wm_reqstate.socket, 
-		 [make_version(wrq:version(RD)),
+    {"100-continue", _} ->
+        send(PassedState#wm_reqstate.socket,
+         [make_version(wrq:version(RD)),
                   make_code(100), <<"\r\n\r\n">>]);
-	_Else ->
-	    ok
+    _Else ->
+        ok
     end,
     case body_length() of
         {unknown_transfer_encoding, X} -> exit({unknown_transfer_encoding, X});
@@ -453,11 +453,11 @@ read_chunk_length(Socket) ->
 
 get_range() ->
     case get_header_value("range") of
-	{undefined, _} ->
-	    {undefined, ReqState#wm_reqstate{range=undefined}};
-	{RawRange, _} ->
-	    Range = parse_range_request(RawRange),
-	    {Range, ReqState#wm_reqstate{range=Range}}
+    {undefined, _} ->
+        {undefined, ReqState#wm_reqstate{range=undefined}};
+    {RawRange, _} ->
+        Range = parse_range_request(RawRange),
+        {Range, ReqState#wm_reqstate{range=Range}}
     end.
 
 range_parts(_RD=#wm_reqdata{resp_body={file, IoDevice}}, Ranges) ->
@@ -538,12 +538,12 @@ parse_range_request(RawRange) when is_list(RawRange) ->
 parts_to_body([{Start, End, Body}], Size) ->
     %% return body for a range reponse with a single body
     ContentType = 
-	case get_outheader_value("content-type") of
-	    {undefined, _} ->
-		"text/html";
-	    {CT, _} ->
-		CT
-	end,
+    case get_outheader_value("content-type") of
+        {undefined, _} ->
+        "text/html";
+        {CT, _} ->
+        CT
+    end,
     HeaderList = [{"Content-Type", ContentType},
                   {"Content-Range",
                    ["bytes ",
@@ -556,12 +556,12 @@ parts_to_body(BodyList, Size) when is_list(BodyList) ->
     %% header Content-Type: multipart/byteranges; boundary=441934886133bdee4
     %% and multipart body
     ContentType = 
-	case get_outheader_value("content-type") of
-	    {undefined, _} ->
-		"text/html";
-	    {CT, _} ->
-		CT
-	end,
+    case get_outheader_value("content-type") of
+        {undefined, _} ->
+        "text/html";
+        {CT, _} ->
+        CT
+    end,
     Boundary = mochihex:to_hex(crypto:rand_bytes(8)),
     HeaderList = [{"Content-Type",
                    ["multipart/byteranges; ",
@@ -609,14 +609,14 @@ make_headers(Code, Length, RD) ->
     ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")",
     WithSrv = mochiweb_headers:enter("Server", ServerHeader, Hdrs0),
     Hdrs = case mochiweb_headers:get_value("date", WithSrv) of
-	undefined ->
+    undefined ->
             mochiweb_headers:enter("Date", httpd_util:rfc1123_date(), WithSrv);
-	_ ->
-	    WithSrv
+    _ ->
+        WithSrv
     end,
     F = fun({K, V}, Acc) ->
-		[mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">> | Acc]
-	end,
+        [mochiweb_util:make_io(K), <<": ">>, V, <<"\r\n">> | Acc]
+    end,
     lists:foldl(F, [<<"\r\n">>], mochiweb_headers:to_list(Hdrs)).
 
 get_reqdata() -> call(get_reqdata).


### PR DESCRIPTION
Is backwards compatible with existing config, but https requires new config of this form:

[
    {http, [{ip, "0.0.0.0"},
            {port, 8098]},

```
{https, [{ip, "0.0.0.0"},
         {port, 8443},
         {ssl, true},
         {ssl_opts, [{certfile, "etc/cert.pem"}, {keyfile, "etc/key.pem"}]}]},

{common, [{log_dir, "log"},
          {backlog, 128},
          {dispatch, []}]}
```

]
