### PR TITLE
For some Content-Type headers, webmachine would crash on boundary detection.

### DIFF
--- a/src/webmachine_multipart.erl
+++ b/src/webmachine_multipart.erl
@@ -48,8 +48,8 @@
 % @spec find_boundary(wrq:wm_reqdata()) -> boundary()
 find_boundary(ReqData) ->
     ContentType = wrq:get_req_header("content-type", ReqData),
-    string:substr(ContentType, string:str(ContentType, "boundary=") 
-                  + length("boundary=")).
+    {match,[Trimmed]} = re:run(ContentType, "boundary=(.*?[^\s;]*)", [{capture, [1], list}]),
+    Trimmed.
 
 % @doc Turn a multipart form into component parts.
 % @spec get_all_parts(incoming_req_body(), boundary()) -> [fpart()]

--- a/src/webmachine_multipart.erl
+++ b/src/webmachine_multipart.erl
@@ -48,8 +48,9 @@
 % @spec find_boundary(wrq:wm_reqdata()) -> boundary()
 find_boundary(ReqData) ->
     ContentType = wrq:get_req_header("content-type", ReqData),
-    {match,[Trimmed]} = re:run(ContentType, "boundary=(.*?[^\s;]*)", [{capture, [1], list}]),
-    Trimmed.
+    {_,Props} = mochiweb_util:parse_header(ContentType),
+    {"boundary", Boundary} = lists:keyfind("boundary", 1, Props), 
+    Boundary.
 
 % @doc Turn a multipart form into component parts.
 % @spec get_all_parts(incoming_req_body(), boundary()) -> [fpart()]


### PR DESCRIPTION
Sample stolen from Nokia PAP PUSH documentation.

```
POST /PGW/ HTTP/1.1 
Content-Type: multipart/related; boundary=multipart-boundary; type="application/xml" 
Host: 194.137.80.48:5080 
Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2 Connection: keep-alive
Content-Length: 653
```

boundary detection would find `multipart-boundary; type="application/xml"` instead of `multipart-boundary`

This commit fixes it.
