### PR TITLE
Fixing bash path in new_webmachine.sh

### DIFF
--- a/scripts/new_webmachine.sh
+++ b/scripts/new_webmachine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NAME=$1
 DESTDIR=$2


### PR DESCRIPTION
The proper way to invoke bash is the following:
/usr/bin/env bash

It works on linux, *bsd, macos and more :)
