### PR TITLE
include eunit headers only when necessary

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -22,7 +22,6 @@
 -author('Bryan Fink <bryan@basho.com>').
 
 -export([dispatch/2, dispatch/3]).
--include_lib("eunit/include/eunit.hrl").
 
 -define(SEPARATOR, $\/).
 -define(MATCH_ALL, '*').
@@ -206,6 +205,8 @@ calculate_app_root(N) when N > 1 ->
 %%
 %% TEST
 %%
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 
 app_root_test() ->
     ?assertEqual(".",           calculate_app_root(1)),
@@ -394,3 +395,5 @@ dispatch_test() ->
     ?assertEqual({no_dispatch_match, {["bar","baz"],8000}, ["q","r"]},
                  dispatch("baz.bar:8000", "q/r",
                           [{{["foo","bar"],80},[{["a","b","c"],x,y}]}])).
+
+  -endif.

--- a/src/webmachine_multipart.erl
+++ b/src/webmachine_multipart.erl
@@ -21,8 +21,6 @@
 -author('Andy Gross <andy@basho.com>').
 -export([get_all_parts/2,stream_parts/2, find_boundary/1]).
 
--include_lib("eunit/include/eunit.hrl").
-
 % @type incoming_req_body() = binary().
 % The request body, in "multipart/form-data" (rfc2388) form,
 
@@ -143,6 +141,12 @@ send_streamed_body(Body, Max) ->
             {Body, done}
     end.
 
+%%
+%% Tests
+%%
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 body_test() ->
     Body = <<"------------ae0gL6gL6Ij5KM7Ef1KM7ei4ae0cH2\r\nContent-Disposition: form-data; name=\"Filename\"\r\n\r\ntestfile.txt\r\n------------ae0gL6gL6Ij5KM7Ef1KM7ei4ae0cH2\r\nContent-Disposition: form-data; name=\"Filedata\"; filename=\"testfile.txt\"\r\nContent-Type: application/octet-stream\r\n\r\n%%% The contents of this file are a test,\n%%% do not be alarmed.\n\r\n------------ae0gL6gL6Ij5KM7Ef1KM7ei4ae0cH2\r\nContent-Disposition: form-data; name=\"Upload\"\r\n\r\nSubmit Query\r\n------------ae0gL6gL6Ij5KM7Ef1KM7ei4ae0cH2--">>,
     Boundary = "----------ae0gL6gL6Ij5KM7Ef1KM7ei4ae0cH2",
@@ -171,3 +175,5 @@ body2_test() ->
          <<"CAMBRIDGE, MA - February 18, 2009 - Akamai Technologies, Inc. (NASDAQ: AKAM), the leader in powering rich media, dynamic transactions and enterprise applications online, today announced that its Service & Support organization was awarded top honors for Innovation in Customer Service at the 3rd Annual Stevie Awards for Sales & Customer Service, an international competition recognizing excellence in disciplines that are crucial to business success.\n\n\"We have always set incredibly high standards with respect to the service and support we provide our customers,\" said Sanjay Singh, vice president of Global Service & Support at Akamai. \"Our support team provides highly responsive service around the clock to our global customer base and, as a result, has become an extension of our customers' online businesses. This prestigious award is validation of Akamai's commitment to customer service and technical support.\"\n\nAkamai Service & Support professionals are dedicated to working with customers on a daily basis to fine tune, optimize, and support their Internet initiatives. Akamai's winning submission highlighted the key pillars of its service and support offering, as well as the initiatives established to meet customer requirements for proactive communication, simplification, and faster response times.\n\n\"This year's honorees demonstrate that even in challenging economic times, it's possible for organizations to continue to shine in sales and customer service, the two most important functions in business: acquiring and keeping customers,\" said Michael Gallagher, president of the Stevie Awards.\n\nThe awards are presented by the Stevie Awards, which organizes several of the world's leading business awards shows, including the prestigious American Business Awards. Nicknamed the Stevies for the Greek word \"crowned,\" winners were announced during a gala banquet on Monday, February 9 at Caesars Palace in Las Vegas. Nominated customer service and sales executives from the U.S.A. and several other countries attended. More than 500 entries from companies of all sizes and in virtually every industry were submitted to this year's competition. There are 27 categories for customer service professionals, as well as 41 categories for sales professionals.\n\nDetails about the Stevie Awards for Sales & Customer Service and the list of honorees in all categories are available at www.stevieawards.com/sales. \n\r\n">>
         }],
        get_all_parts(Body,Boundary)).
+
+-endif.

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -19,8 +19,6 @@
 %%      the table each time webmachine restarts.
 -module(webmachine_router).
 
--include_lib("eunit/include/eunit.hrl").
-
 -behaviour(gen_server).
 
 %% API
@@ -155,7 +153,12 @@ start() ->
 get_routes() ->
     gen_server:call(?SERVER, get_routes, infinity).
 
+%%
 %% Tests
+%%
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 add_remove_route_test() ->
     application:set_env(webmachine, dispatch_list, []),
     {ok, Pid} = start(),
@@ -187,3 +190,5 @@ no_dupe_path_test() ->
     webmachine_router:add_route(PathSpec),
     [PathSpec] = get_routes(),
     exit(Pid, kill).
+
+-endif.

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -33,7 +33,6 @@
 % @type reqdata(). The opaque data type used for req/resp data structures.
 -include_lib("include/wm_reqdata.hrl").
 -include_lib("include/wm_reqstate.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 
 create(Method,Version,RawPath,Headers) ->
@@ -214,6 +213,13 @@ add_note(K, V, RD) -> RD#wm_reqdata{notes=[{K, V} | RD#wm_reqdata.notes]}.
 
 get_notes(RD) -> RD#wm_reqdata.notes.
 
+%%
+%% Tests
+%%
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 make_wrq(Method, RawPath, Headers) ->
     create(Method, {1,1}, RawPath, mochiweb_headers:from_list(Headers)).
 
@@ -247,3 +253,5 @@ simple_dispatch_test() ->
                            R1),
     ?assertEqual(".", app_root(R)),
     ?assertEqual(80, port(R)).
+
+-endif.


### PR DESCRIPTION
include eunit only within the ifdef(TEST) blocks. This avoids an eunit dependency during non-test compilation.
