### PR TITLE
Mochiweb 1.5.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 {cover_enabled, true}.
 
 {deps, [
-        {mochiweb, "1.7.1", {git, "git://github.com/basho/mochiweb",
-                            {tag, "mochiweb-1.7.1"}}}
+        {mochiweb, "1.5.1", {git, "git://github.com/mochi/mochiweb",
+                            {tag, "1.5.1"}}}
         ]}.


### PR DESCRIPTION
This change switches away from the basho fork of mochiweb to the official version found at http://github.com/mochi/mochiweb.

It builds without warnings and all tests pass with Erlang R14B01.
