### PR TITLE
Drop useless include

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -78,7 +78,6 @@
 -include("webmachine_logger.hrl").
 -include_lib("include/wm_reqstate.hrl").
 -include_lib("include/wm_reqdata.hrl").
--include_lib("mochiweb/include/internal.hrl").
 
 -define(WMVSN, "1.7.3").
 -define(QUIP, "participate in the frantic").


### PR DESCRIPTION
it's safe to remove the inclusion of this header - it only contains definition of the ?RECBUF_SIZE macro which isn't used anywhere in webmachine.
