### PR TITLE
Change the child spec module in the webmachine supervisor template.

### DIFF
--- a/priv/templates/src/wmskel_sup.erl
+++ b/priv/templates/src/wmskel_sup.erl
@@ -52,6 +52,6 @@ init([]) ->
                  {dispatch, Dispatch}],
     Web = {webmachine_mochiweb,
            {webmachine_mochiweb, start, [WebConfig]},
-           permanent, 5000, worker, dynamic},
+           permanent, 5000, worker, [mochiweb_socket_server]},
     Processes = [Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.


### PR DESCRIPTION
The webmachine_mochiweb child starts an instance of the mochiweb_socket_server. The mochiweb_socket_server is a gen_server. According to the Erlang documentation gen_servers should be specified as [Module] in the child spec.
