### PR TITLE
Fix for default app template crashing (at least on Erlang R13B03)

### DIFF
--- a/priv/templates/src/wmskel.app.src
+++ b/priv/templates/src/wmskel.app.src
@@ -8,6 +8,7 @@
   {applications, [
                   kernel,
                   stdlib,
+		  inets,
                   crypto,
                   mochiweb,
                   webmachine

--- a/priv/templates/src/wmskel.app.src
+++ b/priv/templates/src/wmskel.app.src
@@ -8,7 +8,7 @@
   {applications, [
                   kernel,
                   stdlib,
-		  inets,
+                  inets,
                   crypto,
                   mochiweb,
                   webmachine

--- a/priv/templates/src/wmskel.erl
+++ b/priv/templates/src/wmskel.erl
@@ -18,6 +18,7 @@ ensure_started(App) ->
 %% @spec start_link() -> {ok,Pid::pid()}
 %% @doc Starts the app for inclusion in a supervisor tree
 start_link() ->
+    ensure_started(inets),
     ensure_started(crypto),
     ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 
@@ -28,7 +29,7 @@ start_link() ->
 %% @spec start() -> ok
 %% @doc Start the {{appid}} server.
 start() ->
-    inets:start(),
+    ensure_started(inets),
     ensure_started(crypto),
     ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 
@@ -43,4 +44,5 @@ stop() ->
     application:stop(webmachine),
     application:stop(mochiweb),
     application:stop(crypto),
+    application:stop(inets),
     Res.

--- a/priv/templates/src/wmskel.erl
+++ b/priv/templates/src/wmskel.erl
@@ -28,6 +28,7 @@ start_link() ->
 %% @spec start() -> ok
 %% @doc Start the {{appid}} server.
 start() ->
+    inets:start(),
     ensure_started(crypto),
     ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 


### PR DESCRIPTION
Couldn't get a demo app running from a fresh new_machine.sh, googling the error found a fix here: https://gist.github.com/878868

(awesome project btw!)
