### PR TITLE
Adding support for more mime types.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,12 @@
 {cover_enabled, true}.
 
 {deps, [
-        {mochiweb, "1.5.1", {git, "git://github.com/mochi/mochiweb",
-                            {tag, "1.5.1"}}}
+        {mochiweb, "1.5.1",
+         {git, "git://github.com/mochi/mochiweb",
+          {tag, "1.5.1"}}}
+        
+        , {moo_mime_types, "1.0.2",
+           {git, "git://github.com/etnt/moo_mime_types",
+            {tag, "1.0.2"}}}
+        
         ]}.

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -54,43 +54,53 @@ compare_ims_dates(D1, D2) ->
 %% @doc  Guess the mime type of a file by the extension of its filename.
 guess_mime(File) ->
     case filename:extension(File) of
-        ".html" ->
+        "."++Extension ->
+            try moo_mime_types:t(Extension)
+            catch _:_ -> fallback_guess_mime(Extension) end;
+        _ ->
+            "application/octet-stream"
+    end.
+                    
+%% Retaining the old webmachine behaviour.
+fallback_guess_mime(Extension) ->
+    case Extension of
+        "html" ->
             "text/html";
-        ".xhtml" ->
+        "xhtml" ->
             "application/xhtml+xml";
-        ".xml" ->
+        "xml" ->
             "application/xml";
-        ".css" ->
+        "css" ->
             "text/css";
-        ".js" ->
+        "js" ->
             "application/x-javascript";
-        ".jpg" ->
+        "jpg" ->
             "image/jpeg";
-        ".jpeg" ->
+        "jpeg" ->
             "image/jpeg";
-        ".gif" ->
+        "gif" ->
             "image/gif";
-        ".png" ->
+        "png" ->
             "image/png";
-        ".ico" ->
+        "ico" ->
             "image/x-icon";
-        ".swf" ->
+        "swf" ->
             "application/x-shockwave-flash";
-        ".zip" ->
+        "zip" ->
             "application/zip";
-        ".bz2" ->
+        "bz2" ->
             "application/x-bzip2";
-        ".gz" ->
+        "gz" ->
             "application/x-gzip";
-        ".tar" ->
+        "tar" ->
             "application/x-tar";
-        ".tgz" ->
+        "tgz" ->
             "application/x-gzip";
-        ".htc" ->
+        "htc" ->
             "text/x-component";
-        ".manifest" ->
+        "manifest" ->
             "text/cache-manifest";
-        ".svg" ->
+        "svg" ->
             "image/svg+xml";
         _ ->
             "text/plain"


### PR DESCRIPTION
Hi, 

I've added a dependency to a package named moo_mime_type and is making use of it
in the webmachine_util:guess_mime/1 code. The moo_mime_type code is basically
stolen from yaws and generates the moo_mime_types.erl file based on a mime.types
file, originally taken from Apache. Any updates with new mime types is done in this file
and a new moo_mime_types.erl file is generated and checked in. In case the moo_mime_types
code should fail (?), the old webmachine guss_mime code is used as a fallback.

Btw: the old code returned 'text/plain' as default, perhaps is should return: 'application/octet-stream' ?

Cheers, Tobbe
