### PR TITLE
Fix edoc errors (macros and includes)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 %%-*- mode: erlang -*-
 {fail_on_warning, true}.
 {cover_enabled, true}.
+{edoc_opts, [{preprocess, true}]}.
 
 {deps, [
         {mochiweb, "1.5.1", {git, "git://github.com/mochi/mochiweb",

--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -21,8 +21,8 @@
 -export([new_request/2]).
 
 -include("webmachine_logger.hrl").
--include_lib("include/wm_reqstate.hrl").
--include_lib("include/wm_reqdata.hrl").
+-include("wm_reqstate.hrl").
+-include("wm_reqdata.hrl").
 
 %% @spec start() -> ok
 %% @doc Start the webmachine server.

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -76,8 +76,8 @@
         ]).
 
 -include("webmachine_logger.hrl").
--include_lib("include/wm_reqstate.hrl").
--include_lib("include/wm_reqdata.hrl").
+-include("wm_reqstate.hrl").
+-include("wm_reqdata.hrl").
 -include_lib("mochiweb/include/internal.hrl").
 
 -define(WMVSN, "1.7.3").

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -20,8 +20,8 @@
 -export([wrap/2]).
 -export([do/2,log_d/1,stop/0]).
 
--include_lib("include/wm_reqdata.hrl").
--include_lib("include/wm_reqstate.hrl").
+-include("wm_reqdata.hrl").
+-include("wm_reqstate.hrl").
 
 default(ping) ->
     no_default;

--- a/src/wmtrace_resource.erl
+++ b/src/wmtrace_resource.erl
@@ -14,7 +14,7 @@
          produce_map/2,
          produce_css/2]).
 
--include("include/wm_reqdata.hrl").
+-include("wm_reqdata.hrl").
 
 -record(ctx, {trace_dir, trace}).
 

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -31,8 +31,8 @@
          add_note/3, get_notes/1]).
 
 % @type reqdata(). The opaque data type used for req/resp data structures.
--include_lib("include/wm_reqdata.hrl").
--include_lib("include/wm_reqstate.hrl").
+-include("wm_reqdata.hrl").
+-include("wm_reqstate.hrl").
 
 
 create(Method,Version,RawPath,Headers) ->


### PR DESCRIPTION
As Björn reported (http://lists.therestfulway.com/pipermail/webmachine_lists.therestfulway.com/2011-May/000505.html), edoc didn't like wmtrace_resource's use of macros.  After clearing that up, edoc didn't like some of the include defs.  These two commits should fix both problems.
