### PR TITLE
removes proplists in favor of lists:keyfind for performance

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -111,7 +111,10 @@ loop(MochiReq) ->
     end.
 
 get_option(Option, Options) ->
-    {proplists:get_value(Option, Options), proplists:delete(Option, Options)}.
+    case lists:keyfind(Option, 1, Options) of
+       false -> {undefined, Options};
+       {Option, Value} -> {Value, lists:keydelete(Option,1, Options)}
+    end.
 
 host_headers(Req) ->
     [ V || {V,_ReqState} <- [Req:get_header_value(H)

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -737,17 +737,25 @@ req_cookie() -> call(req_cookie).
 parse_cookie() -> req_cookie().
 get_cookie_value(Key) ->
     {ReqCookie, NewReqState} = req_cookie(),
-    {proplists:get_value(Key, ReqCookie), NewReqState}.
+    case lists:keyfind(Key, 1, ReqCookie) of
+        false -> {undefined, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 
 req_qs() -> call(req_qs).
 parse_qs() -> req_qs().
 get_qs_value(Key) ->
     {ReqQS, NewReqState} = req_qs(),
-    {proplists:get_value(Key, ReqQS), NewReqState}.
+    case lists:keyfind(Key, 1, ReqQS) of
+        false -> {undefined, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 get_qs_value(Key, Default) ->
     {ReqQS, NewReqState} = req_qs(),
-    {proplists:get_value(Key, ReqQS, Default), NewReqState}.
-
+    case lists:keyfind(Key, 1, ReqQS) of
+        false -> {Default, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 set_resp_body(Body) -> call({set_resp_body, Body}).
 resp_body() -> call(resp_body).
 response_body() -> resp_body().

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -118,7 +118,10 @@ wrap(Mod, Args) ->
     end.
 
 do(Fun, ReqProps) when is_atom(Fun) andalso is_list(ReqProps) ->
-    RState0 = proplists:get_value(reqstate, ReqProps),
+    case lists:keyfind(reqstate, 1, ReqProps) of
+        false -> RState0 = undefined;
+        {reqstate, RState0} -> ok
+    end,
     put(tmp_reqstate, empty),
     {Reply, ReqData, NewModState} = handle_wm_call(Fun, 
                     (RState0#wm_reqstate.reqdata)#wm_reqdata{wm_state=RState0}),

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -201,14 +201,22 @@ append_to_response_body(Data, RD=#wm_reqdata{resp_body=RespB}) ->
     end.
 
 get_cookie_value(Key, RD) when is_list(Key) -> % string
-    proplists:get_value(Key, req_cookie(RD)).
+    case lists:keyfind(Key, 1, req_cookie(RD)) of
+        false -> undefined;
+        {Key, Value} -> Value
+    end.
 
 get_qs_value(Key, RD) when is_list(Key) -> % string
-    proplists:get_value(Key, req_qs(RD)).
+    case lists:keyfind(Key, 1, req_qs(RD)) of
+        false -> undefined;
+        {Key, Value} -> Value
+    end.
 
 get_qs_value(Key, Default, RD) when is_list(Key) ->
-    proplists:get_value(Key, req_qs(RD), Default).
-
+    case lists:keyfind(Key, 1, req_qs(RD)) of
+        false -> Default;
+        {Key, Value} -> Value
+    end.
 add_note(K, V, RD) -> RD#wm_reqdata{notes=[{K, V} | RD#wm_reqdata.notes]}.
 
 get_notes(RD) -> RD#wm_reqdata.notes.


### PR DESCRIPTION
This morning while watching bashochat, I saw that andrew said "switching proplists to lists is a significant win", which encouraged me to submit this pull request.

About 6 months ago  I switched all the proplists:get_value to lists:keyfind.  I never issued a pull request because I thought it was trivial, but given the chat this morning I was inspired to finally submit it.  I made sure it was all up-to-date with basho/webmachine/tree/master so it should merge nicely.

Thanks.
