### PR TITLE
Changed webmachine_util:format_content_type/2 to support media types with parameters as Key, Value tuples.

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -192,6 +192,7 @@ normalize_provided1(Type) when is_list(Type) -> {Type, []};
 normalize_provided1({Type,Params}) -> {Type, Params}.
 
 format_content_type(Type,[]) -> Type;
+format_content_type(Type,[{K,V}|T]) -> format_content_type(Type ++ "; " ++ K ++ "=" ++ V, T);
 format_content_type(Type,[H|T]) -> format_content_type(Type ++ "; " ++ H, T).
 
 choose_charset(CSets, AccCharHdr) -> do_choose(CSets, AccCharHdr, "ISO-8859-1").


### PR DESCRIPTION
This fixes an error where an Accept header of "audio/vnd.wave; codec=31" with a media type to handler mapping of '{{"audio/vnd.wave", [{"codec", "31"}]}, foo }' in the content_types_provided/2 resource function would make webmachine crash with 

[{erlang,'++',
         [[97,117,100,105,111,47,118,110,100,46,119,97,118,101,59,32|
           {"codec","31"}],
          []]},
 {webmachine_decision_core,decision,1},
 {webmachine_decision_core,handle_request,2},
 {webmachine_mochiweb,loop,1},
 {mochiweb_http,headers,5},
 {proc_lib,init_p_do_apply,3}]
