### PR TITLE
AZ460 - Update webmachine dispatch list to support guard function.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -18,3 +18,4 @@ Arjan Scherpenisse
 Benjamin Black
 Anthony Molinaro
 Phil Pirozhkov
+Rusty Klophaus

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -69,7 +69,8 @@ loop(MochiReq) ->
                [] -> []
            end,
     {Path, _} = Req:path(),
-    case webmachine_dispatcher:dispatch(Host, Path, DispatchList) of
+    {RD, _} = Req:get_reqdata(),
+    case webmachine_dispatcher:dispatch(Host, Path, DispatchList, RD) of
         {no_dispatch_match, _UnmatchedHost, _UnmatchedPathTokens} ->
             {ok, ErrorHandler} = application:get_env(webmachine, error_handler),
             {ErrorHTML,ReqState1} = 

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -247,7 +247,7 @@ simple_dispatch_test() ->
     R1 = set_peer("127.0.0.1", R0),    
     {_, _, HostTokens, Port, PathTokens, Bindings, AppRoot, StringPath} = 
         webmachine_dispatcher:dispatch("127.0.0.1", "/foo", 
-                                       [{["foo"], foo_resource, []}]),
+                                       [{["foo"], foo_resource, []}], R1),
     R = load_dispatch_data(Bindings,
                            HostTokens,
                            Port,


### PR DESCRIPTION
Update webmachine to dispatch guards. Can now use path specs of the form `{PathSpec, Guard, Mod, Options}` where Guard is either a function or a {Mod, Fun} tuple. The function has arity 1. Webmachine runs the guard, passing in the request object as the sole parameter. The route can only match if the function returns true.
