### PR TITLE
set a default error handler so hot-upgrades don't cause webmachine to ret

### DIFF
--- a/ebin/webmachine.app
+++ b/ebin/webmachine.app
@@ -23,6 +23,7 @@
   {registered, []},
   {mod, {webmachine_app, []}},
   {env, [
-         {dispatch_list, []}
+         {dispatch_list, []},
+         {error_handler, webmachine_error_handler}
         ]},
   {applications, [kernel, stdlib, crypto]}]}.


### PR DESCRIPTION
Hot upgrades cause the application environment variables to clear, so the error_handler and dispatch_list both are empty afterwards. Currently this causes the webmachine_mochiweb:loop/1 to crap out due to getting an undefined on application:get_env(webmachine, dispatch_list) which causes webmachine to return empty responses. Post-upgrade restarting webmachine_mochiweb fixes this. To improve this behavior this patch adds {error_handler, webmachine_error_handler} to the webmachine appfile. With this default set post-upgrade webmachine is only missing the dispatch_list which results in 404 responses, far preferable to empty responses.
