### PR TITLE
Validate Content-MD5 header

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -195,14 +195,10 @@ decision(v3b9a) ->
             case BodyHash =:= Checksum of
                 true -> d(v3b9b);
                 _ ->
-                    wrcall({set_resp_header, "Content-Type", "text/plain"}),
-                    wrcall({set_resp_body, "Content-MD5 header does not match request body."}),
-                    respond(400)
+                    error_response(400, <<"Content-MD5 header does not match request body.">>)
             end;
         false ->
-            wrcall({set_resp_header, "Content-Type", "text/plain"}),
-            wrcall({set_resp_body, "Content-MD5 header does not match request body."}),
-            respond(400);
+            error_response(400, <<"Content-MD5 header does not match request body.">>);
         _ -> d(v3b9b)
     end;
 %% "Malformed?"

--- a/src/webmachine_error_handler.erl
+++ b/src/webmachine_error_handler.erl
@@ -51,7 +51,7 @@ render_error_body(501, Req, _Reason) ->
     error_logger:error_msg("Webmachine does not support method ~p~n",
                            [Method]),
     ErrorStr = io_lib:format("<html><head><title>501 Not Implemented</title>"
-                             "</head><body><h1>Internal Server Error</h1>"
+                             "</head><body><h1>Not Implemented</h1>"
                              "The server does not support the ~p method.<br>"
                              "<P><HR><ADDRESS>mochiweb+webmachine web server"
                              "</ADDRESS></body></html>",
@@ -69,5 +69,19 @@ render_error_body(503, Req, _Reason) ->
                "or maintenance of the server.<br>"
                "<P><HR><ADDRESS>mochiweb+webmachine web server"
                "</ADDRESS></body></html>",
-    {list_to_binary(ErrorStr), ReqState}.
+    {list_to_binary(ErrorStr), ReqState};
+
+render_error_body(Code, Req, Reason) ->
+    {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
+    ReasonPhrase = httpd_util:reason_phrase(Code),
+    Body = ["<html><head><title>",
+            integer_to_list(Code),
+            " ",
+            ReasonPhrase,
+            "</title></head><body><h1>",
+            ReasonPhrase,
+            "</h1>",
+            Reason,
+            "<p><hr><address>mochiweb+webmachine web server</address></body></html>"],
+    {iolist_to_binary(Body), ReqState}.
 

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -100,6 +100,8 @@ default(generate_etag) ->
     undefined;
 default(finish_request) ->
     true;
+default(validate_content_checksum) ->
+    not_validated;
 default(_) ->
     no_default.
           


### PR DESCRIPTION
Adds validation of the Content-MD5 header when submitted with a request body.
- Returns `400 Bad Request` when Content-MD5 header doesn't match checksum of request body.
- Adds optional `validate_content_checksum` resource callback. Resource can return `false` if the checksum fails, `not_validated` (default) to use the default validation, or anything else (e.g. `true` or `ignore`) to continue normal flow.
- Adds generic error rendering function to `webmachine_error_handler`.

Example of implicit usage: https://gist.github.com/584d6b86ec58f83ecba5

TODO: 
- Handles both plain and streamed/chunked responses, but sets the request body state after streaming (might break some things?). Please review.
