### PR TITLE
AZ564 - Update webmachine guard to include matched path information

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -206,16 +206,6 @@ try_path_binding([PathSpec|Rest], PathTokens, HostRemainder, Port, HostBindings,
             case run_guard(Guard, RD1) of
                 true ->
                     {Mod, Props, Remainder, NewBindings, AppRoot, StringPath};
-                    %% {Mod, Props, PathRemainder, PathBindings, AppRoot, StringPath} - from try_path_binding
-                    %% {Mod, Props, PathRemainder, PathBindings, AppRoot, StringPath} - to try_host_binding
-                    %% {Mod, Props, HostRemainder, Port, PathRemainder, PathBindings, AppRoot, StringPath}} - from try_host_binding
-                    %% {Mod, ModOpts, HostTokens, Port, PathTokens, Bindings, AppRoot, StringPath} - to loop
-                    %% {Bindings,  HostTokens, Port, PathTokens, AppRoot, StringPath} - from loop
-                    %% {Bindings,  HostTokens, Port, PathTokens, AppRoot, DispPath) - to load_dispatch_data
-                    %% {Bindings,  HostTokens, Port, PathTokens, AppRoot, DispPath) - from load_dispatch_data
-                    %% {PathProps, HostTokens, Port, PathTokens, AppRoot, DispPath) - to call/load_dispatch_data
-                    %% {PathInfo,  HostTokens, Port, PathTokens, AppRoot, DispPath) - from call/load_dispatch_data
-
                 false ->
                     try_path_binding(Rest, PathTokens, HostRemainder, Port, HostBindings, ExtraDepth, RD)
             end;

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -92,6 +92,7 @@ get_peer() ->
     case ReqState#wm_reqstate.peer of
     undefined ->
         PeerName = case ReqState#wm_reqstate.socket of
+            testing -> {ok, {{127,0,0,1}, 80}};
             {ssl,SslSocket} -> ssl:peername(SslSocket);
             _ -> inet:peername(ReqState#wm_reqstate.socket)
         end,

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -139,8 +139,12 @@ filter_by_resource({_, _, _}, _Resource) ->
     true.
 
 get_dispatch_list() ->
-    {ok, Dispatch} = application:get_env(webmachine, dispatch_list),
-    Dispatch.
+    case application:get_env(webmachine, dispatch_list) of
+        {ok, Dispatch} ->
+            Dispatch;
+        undefined ->
+            []
+    end.
 
 set_dispatch_list(DispatchList) ->
     ok = application:set_env(webmachine, dispatch_list, DispatchList),


### PR DESCRIPTION
We recently added "guard functions" to the webmachine dispatch list, which means you could specify a function to run as a final step after all of the hostname and path matching. (If the function returns true, then the route is an acceptable match.)

The guard function takes a single parameter, the `#wm_reqdata` record. Previously, we did not update the `#wm_reqdata` object with hostname or path tokens before calling the guard function.

This pull request adds code to update `#wm_reqdata` record before calling the guard. This allows the user to  call functions like `wrq:path_info(token, RD)`, just like they would in the webmachine resource, with the expected results.
