### PR TITLE
Set a default dispatch_list.

### DIFF
--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -139,8 +139,12 @@ filter_by_resource({_, _, _}, _Resource) ->
     true.
 
 get_dispatch_list() ->
-    {ok, Dispatch} = application:get_env(webmachine, dispatch_list),
-    Dispatch.
+    case application:get_env(webmachine, dispatch_list) of
+        {ok, Dispatch} ->
+            Dispatch;
+        undefined ->
+            []
+    end.
 
 set_dispatch_list(DispatchList) ->
     ok = application:set_env(webmachine, dispatch_list, DispatchList),


### PR DESCRIPTION
The dispatch_list variable used to be set to an empty list in webmachine.app. The following pull request (https://github.com/basho/webmachine/pull/32) removed the dispatch_list variable from webmachine.app, causing the default dispatch list to be undefined, causing problems in unit tests that assumed an empty--but defined--dispatch list.

This pull request causes webmachine to return an empty list rather than undefined if the dispatch list is undefined. My understanding, based on pull request https://github.com/basho/webmachine/pull/31 is that we can't specify a dispatch_list in webmachine.app because it affects hot upgrades.
