### PR TITLE
host_tokens in wm_reqdata is reversed

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -124,7 +124,7 @@ x_peername(Default) ->
 call(base_uri) ->
     RD = ReqState#wm_reqstate.reqdata,
     Scheme = erlang:atom_to_list(RD#wm_reqdata.scheme),
-    Host = string:join(RD#wm_reqdata.host_tokens, "."),
+    Host = string:join(lists:reverse(RD#wm_reqdata.host_tokens), "."),
     PortString = port_string(Scheme, RD#wm_reqdata.port),
     {Scheme ++ "://" ++ Host ++ PortString,ReqState};
 call(socket) -> {ReqState#wm_reqstate.socket,ReqState};


### PR DESCRIPTION
In the locationheader created by webmachine, the host_token is reversed. Example : 1.0.0.127 and not 127.0.0.1
To fix this problem i inserted a lists:reverse in line 129, but i think that it must be fixed in the root. 
