### PR TITLE
I used create_path in my resource and when i used wrq:disp_path i expecte

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -438,7 +438,7 @@ decision(v3n11) ->
                                     end
                             end,
                             FullPath = filename:join(["/", wrcall(path), NewPath]),
-                            wrcall({set_disp_path, FullPath}),
+                            wrcall({set_disp_path, NewPath}),
                             case wrcall({get_resp_header, "Location"}) of
                                 undefined -> wrcall({set_resp_header, "Location", BaseUri ++ FullPath});
                                 _ -> ok


### PR DESCRIPTION
I used create_path in my resource and when i used wrq:disp_path i expected not the full path. After viewing at the sources, i saw that you set the FullPath and not the NewPath in line 441. I changed this to the NewPath.
