### PR TITLE
Fix reversed hostname tokens on calling call(base_uri)

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -125,7 +125,7 @@ x_peername(Default) ->
 call(base_uri) ->
     RD = ReqState#wm_reqstate.reqdata,
     Scheme = erlang:atom_to_list(RD#wm_reqdata.scheme),
-    Host = string:join(RD#wm_reqdata.host_tokens, "."),
+    Host = string:join(lists:reverse(RD#wm_reqdata.host_tokens), "."),
     PortString = port_string(Scheme, RD#wm_reqdata.port),
     {Scheme ++ "://" ++ Host ++ PortString,ReqState};
 call(socket) -> {ReqState#wm_reqstate.socket,ReqState};


### PR DESCRIPTION
Host tokens are stored reversed. When forming the string for the base_uri, this should be reversed back.
