### PR TITLE
minor change to wmskel to make it compatible with erlang releases

### DIFF
--- a/priv/templates/src/wmskel_sup.erl
+++ b/priv/templates/src/wmskel_sup.erl
@@ -43,8 +43,7 @@ upgrade() ->
 init([]) ->
     Ip = case os:getenv("WEBMACHINE_IP") of false -> "0.0.0.0"; Any -> Any end,
     {ok, Dispatch} = file:consult(filename:join(
-                         [filename:dirname(code:which(?MODULE)),
-                          "..", "priv", "dispatch.conf"])),
+                         [code:priv_dir({{appid}}), "dispatch.conf"])),
     WebConfig = [
                  {ip, Ip},
                  {port, 8000},


### PR DESCRIPTION
change how dispatch.conf is located, in order to make webmachine projects work with erlang releases

When you do an erlang release, ebin and priv directories do not end up in the same parent directory. As a result of that, the previous method of locating dispatch.conf fails, and webmachine crashes.
