### PR TITLE
Added .less and .coffee support to webmachine_util:guess_mime/1.

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -92,6 +92,10 @@ guess_mime(File) ->
             "text/cache-manifest";
         ".svg" ->
             "image/svg+xml";
+        ".less" ->
+            "text/less";
+        ".coffee" ->
+            "application/x-coffeescript";
         _ ->
             "text/plain"
     end.


### PR DESCRIPTION
The addition of .less (Less CSS) and .coffee (CoffeeScript) file support was useful for me at least in local development, although these can obviously be compiled down to .css and .js respectively, so neither are critical.
