### PR TITLE
Crash when streaming a body back to the client.

### DIFF
--- a/src/webmachine_logger.erl
+++ b/src/webmachine_logger.erl
@@ -98,6 +98,11 @@ maybe_rotate(State, Time) ->
             State#state{hourstamp=ThisHour, handle=Handle}
     end.    
 
+format_length(chunked) ->
+	"chunked";
+format_length(C) ->
+	integer_to_list(C).
+	
 format_req(#wm_log_data{method=Method, 
                         headers=Headers, 
                         peer=Peer, 
@@ -108,7 +113,7 @@ format_req(#wm_log_data{method=Method,
     User = "-",
     Time = fmtnow(),
     Status = integer_to_list(ResponseCode),
-    Length = integer_to_list(ResponseLength),
+    Length = format_length(ResponseLength),
     Referer = 
         case mochiweb_headers:get_value("Referer", Headers) of
             undefined -> "";


### PR DESCRIPTION
I was attempting to stream a request back to the client with a {stream, streambody()} response. This resulted in a crash in webmachine_logger when calling integer_to_list with the atom 'chunked'.

=ERROR REPORT==== 30-Sep-2011::11:24:35 ===
*\* Generic server webmachine_logger terminating 
*\* Last message in was {'$gen_cast',
                        {log_access,
                         {wm_log_data,file_srv,
                          {1317,396275,125864},
                          'HEAD',
                          {4,
                           {"user-agent",
                            {'User-Agent',
                             "curl/7.21.4 (i386-pc-win32) libcurl/7.21.4 OpenSSL/0.9.8r zlib/1.2.5 libidn/1.18 libssh2/1.2.7 librtmp/2.3"},
                            {"host",
                             {'Host',"localhost:8000"},
                             {"accept",{'Accept',"_/_"},nil,nil},
                             nil},
                          "127.0.0.1","/files/sqlncli.msi",
                          {1,1},
                          200,chunked,
                          {1317,396275,172860},
                          {1317,396275,172861},
                          []}}}
*\* When Server state == {state,
                            {2011,9,30,15},
                            "priv/log/access.log",
                            {webmachine_logger,
                                "priv/log/access.log.2011_09_30_15",
                                {file_descriptor,prim_file,
                                    {#Port<0.3555>,720}}}}
*\* Reason for termination == 
*\* {badarg,[{erlang,integer_to_list,[chunked]},
            {webmachine_logger,format_req,1},
            {webmachine_logger,handle_cast,2},
            {gen_server,handle_msg,5},
            {proc_lib,init_p_do_apply,3}]}
