### PR TITLE
Minor edoc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ distclean: clean
 	@(./rebar delete-deps)
 
 edoc:
-	@$(ERL) -noshell -run edoc_run application '$(APP)' '"."' '[{preprocess, true},{includes, ["."]}]'
+	@$(ERL) -noshell -run edoc_run application '$(APP)' '"."' '[{preprocess, true},{includes, [".", "deps"]}]'
 
 test: all
 	@(./rebar skip_deps=true eunit)

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -26,7 +26,7 @@
 -define(SEPARATOR, $\/).
 -define(MATCH_ALL, '*').
 
-%% @spec dispatch(Path::string(), DispatchList::[matchterm()]) ->
+%% @spec dispatch(Path::string(), DispatchList::[matchterm()], ReqData) ->
 %%                                            dispterm() | dispfail()
 %% @doc Interface for URL dispatching.
 %% See also http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
@@ -34,7 +34,7 @@ dispatch(PathAsString, DispatchList, RD) ->
     dispatch([], PathAsString, DispatchList, RD).
 
 %% @spec dispatch(Host::string(), Path::string(),
-%%                DispatchList::[matchterm()]) ->
+%%                DispatchList::[matchterm()], ReqData) ->
 %%         dispterm() | dispfail()
 %% @doc Interface for URL dispatching.
 %% See also http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -109,7 +109,7 @@ split_host(HostAsString) ->
 % create a binding in the result if a complete match occurs.
 
 %% @type guardfun() = function(wrq:reqdata()) -> boolean()
-%%                  | {Mod::atom(), Fun::atom()}
+%%                  | {Mod::atom(), Fun::atom()}.
 % This function or tuple representing a function, if present, is
 % called after a successful match of the host, port, and path for a
 % dispatch entry. The function should take a single argument, the


### PR DESCRIPTION
Fix some minor problems in edoc generation.  I am still getting an error that I am not familiar enough with edoc syntax to fix:

```
./src/webmachine_dispatcher.erl, function try_host_binding/6: at line 111: unknown error parsing type definition: {111,edoc_parser,
                                    ["syntax error before: ","'->'"]}.
```
