### PR TITLE
Add wrq:base_uri/1 and tests, also fixes bug in location URI generation

### DIFF
--- a/priv/templates/src/wmskel_sup.erl
+++ b/priv/templates/src/wmskel_sup.erl
@@ -52,6 +52,6 @@ init([]) ->
                  {dispatch, Dispatch}],
     Web = {webmachine_mochiweb,
            {webmachine_mochiweb, start, [WebConfig]},
-           permanent, 5000, worker, dynamic},
+           permanent, 5000, worker, [mochiweb_socket_server]},
     Processes = [Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.

--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
 
 {deps, [
         {mochiweb, "1.5.1", {git, "git://github.com/basho/mochiweb",
-                            {tag, "1.5.1-http-headers-fix"}}}
+                            {tag, "1.5.1-riak-1.0.x-fixes"}}}
         ]}.

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -438,7 +438,7 @@ decision(v3n11) ->
                                     end
                             end,
                             FullPath = filename:join(["/", wrcall(path), NewPath]),
-                            wrcall({set_disp_path, FullPath}),
+                            wrcall({set_disp_path, NewPath}),
                             case wrcall({get_resp_header, "Location"}) of
                                 undefined -> wrcall({set_resp_header, "Location", BaseUri ++ FullPath});
                                 _ -> ok

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -47,23 +47,26 @@ dispatch(HostAsString, PathAsString, DispatchList, RD) ->
                      true -> 1;
                      _ -> 0
                  end,
-    {Host, Port} = split_host_port(HostAsString),
+    {Host, Port} = split_host_port(HostAsString, wrq:scheme(RD)),
     try_host_binding(DispatchList, lists:reverse(Host), Port,
                      Path, ExtraDepth, RD).
 
-split_host_port(HostAsString) ->
+split_host_port(HostAsString, Scheme) ->
     case string:tokens(HostAsString, ":") of
         [HostPart, PortPart] ->
             {split_host(HostPart), list_to_integer(PortPart)};
         [HostPart] ->
-            {split_host(HostPart), 80};
+            {split_host(HostPart), default_port(Scheme)};
         [] ->
             %% no host header
-            {[], 80}
+            {[], default_port(Scheme)}
     end.
 
 split_host(HostAsString) ->
     string:tokens(HostAsString, ".").
+
+default_port(http) -> 80;
+default_port(https) -> 443.
 
 %% @type matchterm() = hostmatchterm() | pathmatchterm().
 % The dispatch configuration is a list of these terms, and the
@@ -278,11 +281,17 @@ split_host_test() ->
     ?assertEqual(["foo","bar","baz"], split_host("foo.bar.baz")).
 
 split_host_port_test() ->
-    ?assertEqual({[], 80}, split_host_port("")),
+    ?assertEqual({[], 80}, split_host_port("", http)),
     ?assertEqual({["foo","bar","baz"], 80},
-                 split_host_port("foo.bar.baz:80")),
+                 split_host_port("foo.bar.baz:80", http)),
     ?assertEqual({["foo","bar","baz"], 1234},
-                 split_host_port("foo.bar.baz:1234")).
+                 split_host_port("foo.bar.baz:1234", http)),
+
+    ?assertEqual({[], 443}, split_host_port("", https)),
+    ?assertEqual({["foo","bar","baz"], 443},
+                 split_host_port("foo.bar.baz", https)),
+    ?assertEqual({["foo","bar","baz"], 1234},
+                 split_host_port("foo.bar.baz:1234", https)).
 
 %% port binding
 bind_port_simple_match_test() ->
@@ -444,7 +453,8 @@ try_host_binding_fail_test() ->
                  try_host_binding([], ["bar","foo"], 1234, ["x","y","z"], 0, RD)).
 
 dispatch_test() ->
-    RD = testing,
+    %% RD = testing,
+    RD = wrq:create('GET', http, {1,1}, "testing", mochiweb_headers:from_list([])),
     TrueFun = fun(_) -> true end,
     FalseFun = fun(_) -> false end,
 

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -113,9 +113,9 @@ handle_error(Code, Error, Req) ->
 
 
 get_option(Option, Options) ->
-    case lists:keyfind(Option, 1, Options) of
+    case lists:keytake(Option, 1, Options) of
        false -> {undefined, Options};
-       {Option, Value} -> {Value, lists:keydelete(Option,1, Options)}
+       {value, {Option, Value}, NewOptions} -> {Value, NewOptions}
     end.
 
 application_set_unless_env(App, Var, Value) ->

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -111,7 +111,10 @@ loop(MochiReq) ->
     end.
 
 get_option(Option, Options) ->
-    {proplists:get_value(Option, Options), proplists:delete(Option, Options)}.
+    case lists:keyfind(Option, 1, Options) of
+       false -> {undefined, Options};
+       {Option, Value} -> {Value, lists:keydelete(Option,1, Options)}
+    end.
 
 host_headers(Req) ->
     [ V || {V,_ReqState} <- [Req:get_header_value(H)

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -78,7 +78,6 @@
 -include("webmachine_logger.hrl").
 -include_lib("include/wm_reqstate.hrl").
 -include_lib("include/wm_reqdata.hrl").
--include_lib("mochiweb/include/internal.hrl").
 
 -define(WMVSN, "1.7.3").
 -define(QUIP, "participate in the frantic").

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -737,17 +737,25 @@ req_cookie() -> call(req_cookie).
 parse_cookie() -> req_cookie().
 get_cookie_value(Key) ->
     {ReqCookie, NewReqState} = req_cookie(),
-    {proplists:get_value(Key, ReqCookie), NewReqState}.
+    case lists:keyfind(Key, 1, ReqCookie) of
+        false -> {undefined, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 
 req_qs() -> call(req_qs).
 parse_qs() -> req_qs().
 get_qs_value(Key) ->
     {ReqQS, NewReqState} = req_qs(),
-    {proplists:get_value(Key, ReqQS), NewReqState}.
+    case lists:keyfind(Key, 1, ReqQS) of
+        false -> {undefined, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 get_qs_value(Key, Default) ->
     {ReqQS, NewReqState} = req_qs(),
-    {proplists:get_value(Key, ReqQS, Default), NewReqState}.
-
+    case lists:keyfind(Key, 1, ReqQS) of
+        false -> {Default, NewReqState};
+        {Key, Value} -> {Value, NewReqState}
+    end.
 set_resp_body(Body) -> call({set_resp_body, Body}).
 resp_body() -> call(resp_body).
 response_body() -> resp_body().

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -682,7 +682,10 @@ make_headers(Code, Length, RD) ->
                       mochiweb_headers:make(wrq:resp_headers(RD)))
             end
     end,
-    ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")",
+    case application:get_env(webmachine, server_name) of
+      undefined -> ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")";
+      {ok, ServerHeader} when is_list(ServerHeader) -> ok
+    end,
     WithSrv = mochiweb_headers:enter("Server", ServerHeader, Hdrs0),
     Hdrs = case mochiweb_headers:get_value("date", WithSrv) of
         undefined ->

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -122,11 +122,7 @@ x_peername(Default) ->
     end.
 
 call(base_uri) ->
-    RD = ReqState#wm_reqstate.reqdata,
-    Scheme = erlang:atom_to_list(RD#wm_reqdata.scheme),
-    Host = string:join(RD#wm_reqdata.host_tokens, "."),
-    PortString = port_string(Scheme, RD#wm_reqdata.port),
-    {Scheme ++ "://" ++ Host ++ PortString,ReqState};
+    {wrq:base_uri(ReqState#wm_reqstate.reqdata), ReqState};
 call(socket) -> {ReqState#wm_reqstate.socket,ReqState};
 call(get_reqdata) -> {ReqState#wm_reqstate.reqdata, ReqState};
 call({set_reqdata, RD}) -> {ok, ReqState#wm_reqstate{reqdata=RD}};
@@ -809,18 +805,3 @@ load_dispatch_data(Bindings, HostTokens, Port, PathTokens,
           PathTokens, AppRoot, DispPath}).
 
 log_data() -> call(log_data).
-
-port_string(Scheme, Port) ->
-    case Scheme of
-        http ->
-            case Port of
-                80 -> "";
-                _ -> ":" ++ erlang:integer_to_list(Port)
-            end;
-        https ->
-            case Port of
-                443 -> "";
-                _ -> ":" ++ erlang:integer_to_list(Port)
-            end;
-        _ -> ":" ++ erlang:integer_to_list(Port)
-    end.

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -118,7 +118,10 @@ wrap(Mod, Args) ->
     end.
 
 do(Fun, ReqProps) when is_atom(Fun) andalso is_list(ReqProps) ->
-    RState0 = proplists:get_value(reqstate, ReqProps),
+    case lists:keyfind(reqstate, 1, ReqProps) of
+        false -> RState0 = undefined;
+        {reqstate, RState0} -> ok
+    end,
     put(tmp_reqstate, empty),
     {Reply, ReqData, NewModState} = handle_wm_call(Fun, 
                     (RState0#wm_reqstate.reqdata)#wm_reqdata{wm_state=RState0}),

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -54,44 +54,72 @@ compare_ims_dates(D1, D2) ->
 %% @doc  Guess the mime type of a file by the extension of its filename.
 guess_mime(File) ->
     case filename:extension(File) of
-        ".html" ->
-            "text/html";
-        ".xhtml" ->
-            "application/xhtml+xml";
-        ".xml" ->
-            "application/xml";
-        ".css" ->
-            "text/css";
-        ".js" ->
-            "application/x-javascript";
-        ".jpg" ->
-            "image/jpeg";
-        ".jpeg" ->
-            "image/jpeg";
-        ".gif" ->
-            "image/gif";
-        ".png" ->
-            "image/png";
-        ".ico" ->
-            "image/x-icon";
-        ".swf" ->
-            "application/x-shockwave-flash";
-        ".zip" ->
-            "application/zip";
         ".bz2" ->
             "application/x-bzip2";
+        ".css" ->
+            "text/css";
+        ".eot" ->
+            "application/vnd.ms-fontobject";
+        ".gif" ->
+            "image/gif";
         ".gz" ->
             "application/x-gzip";
+        ".htc" ->
+            "text/x-component";
+        ".html" ->
+            "text/html";
+        ".ico" ->
+            "image/x-icon";
+        ".jpeg" ->
+            "image/jpeg";
+        ".jpg" ->
+            "image/jpeg";
+        ".js" ->
+            "application/x-javascript";
+        ".m4v" ->
+            "video/mp4";
+        ".manifest" ->
+            "text/cache-manifest";
+        ".mp4" ->
+            "video/mp4";
+        ".oga" ->
+            "audio/ogg";
+        ".ogg" ->
+            "audio/ogg";
+        ".ogv" ->
+            "video/ogg";
+        ".otf" ->
+            "font/opentyp";
+        ".png" ->
+            "image/png";
+        ".svg" ->
+            "image/svg+xml";
+        ".svgz" ->
+            "image/svg+xml";
+        ".swf" ->
+            "application/x-shockwave-flash";
         ".tar" ->
             "application/x-tar";
         ".tgz" ->
             "application/x-gzip";
-        ".htc" ->
-            "text/x-component";
-        ".manifest" ->
-            "text/cache-manifest";
-        ".svg" ->
-            "image/svg+xml";
+        ".ttc" ->
+            "application/x-font-ttf";
+        ".ttf" ->
+            "application/x-font-ttf";
+        ".vcf" ->
+            "text/x-vcard";
+        ".webm" ->
+            "video/web";
+        ".webp" ->
+            "image/web";
+        ".woff" ->
+            "application/x-font-woff";
+        ".xhtml" ->
+            "application/xhtml+xml";
+        ".xml" ->
+            "application/xml";
+        ".zip" ->
+            "application/zip";
         _ ->
             "text/plain"
     end.

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -20,7 +20,8 @@
 -export([method/1,scheme/1,version/1,peer/1,disp_path/1,path/1,raw_path/1,
          path_info/1,response_code/1,req_cookie/1,req_qs/1,req_headers/1,
          req_body/1,stream_req_body/2,resp_redirect/1,resp_headers/1,
-         resp_body/1,app_root/1,path_tokens/1, host_tokens/1, port/1]).
+         resp_body/1,app_root/1,path_tokens/1, host_tokens/1, port/1,
+         base_uri/1]).
 -export([path_info/2,get_req_header/2,do_redirect/2,fresh_resp_headers/2,
          get_resp_header/2,set_resp_header/3,set_resp_headers/2,
          set_disp_path/2,set_req_body/2,set_resp_body/2,set_response_code/2,
@@ -225,6 +226,27 @@ add_note(K, V, RD) -> RD#wm_reqdata{notes=[{K, V} | RD#wm_reqdata.notes]}.
 
 get_notes(RD) -> RD#wm_reqdata.notes.
 
+base_uri(RD) ->
+    Scheme = erlang:atom_to_list(RD#wm_reqdata.scheme),
+    Host = string:join(lists:reverse(RD#wm_reqdata.host_tokens), "."),
+    PortString = port_string(RD#wm_reqdata.scheme, RD#wm_reqdata.port),
+    Scheme ++ "://" ++ Host ++ PortString.
+
+port_string(Scheme, Port) ->
+    case Scheme of
+        http ->
+            case Port of
+                80 -> "";
+                _ -> ":" ++ erlang:integer_to_list(Port)
+            end;
+        https ->
+            case Port of
+                443 -> "";
+                _ -> ":" ++ erlang:integer_to_list(Port)
+            end;
+        _ -> ":" ++ erlang:integer_to_list(Port)
+    end.
+
 %%
 %% Tests
 %%
@@ -233,7 +255,10 @@ get_notes(RD) -> RD#wm_reqdata.notes.
 -include_lib("eunit/include/eunit.hrl").
 
 make_wrq(Method, RawPath, Headers) ->
-    create(Method, {1,1}, RawPath, mochiweb_headers:from_list(Headers)).
+    make_wrq(Method, http, RawPath, Headers).
+
+make_wrq(Method, Scheme, RawPath, Headers) ->
+    create(Method, Scheme, {1,1}, RawPath, mochiweb_headers:from_list(Headers)).
 
 accessor_test() ->
     R0 = make_wrq('GET', "/foo?a=1&b=2", [{"Cookie", "foo=bar"}]),
@@ -248,7 +273,6 @@ accessor_test() ->
     ?assertEqual([{"foo", "bar"}], req_cookie(R)),
     ?assertEqual("bar", get_cookie_value("foo", R)),
     ?assertEqual("127.0.0.1", peer(R)).
-
     
 simple_dispatch_test() ->
     R0 = make_wrq('GET', "/foo?a=1&b=2", [{"Cookie", "foo=bar"}]),
@@ -264,6 +288,39 @@ simple_dispatch_test() ->
                            StringPath,
                            R1),
     ?assertEqual(".", app_root(R)),
-    ?assertEqual(80, port(R)).
+    ?assertEqual(80, port(R)),
+    ?assertEqual("http://127.0.0.1", base_uri(R)).
+
+base_uri_test_() ->
+    Make_req =
+        fun(Scheme, Host) ->
+                R0 = make_wrq('GET', Scheme, "/foo?a=1&b=2",
+                              [{"Cookie", "foo=bar"}]),
+                R1 = set_peer("127.0.0.1", R0),
+                DispatchRule = {["foo"], foo_resource, []},
+                {_, _, HostTokens, Port, PathTokens,
+                 Bindings, AppRoot,StringPath} =
+                    webmachine_dispatcher:dispatch(Host, "/foo", [DispatchRule],
+                                                   R1),
+                load_dispatch_data(Bindings,
+                                   HostTokens,
+                                   Port,
+                                   PathTokens,
+                                   AppRoot,
+                                   StringPath,
+                                   R1)
+        end,
+    Tests = [{{http, "somewhere.com:8080"}, "http://somewhere.com:8080"},
+             {{https, "somewhere.com:8080"}, "https://somewhere.com:8080"},
+
+             {{http, "somewhere.com"}, "http://somewhere.com"},
+             {{https, "somewhere.com"}, "https://somewhere.com"},
+
+             {{http, "somewhere.com:80"}, "http://somewhere.com"},
+             {{https, "somewhere.com:443"}, "https://somewhere.com"},
+             {{https, "somewhere.com:80"}, "https://somewhere.com:80"},
+             {{http, "somewhere.com:443"}, "http://somewhere.com:443"}],
+    [ ?_assertEqual(Expect, base_uri(Make_req(Scheme, Host)))
+      || {{Scheme, Host}, Expect} <- Tests ].
 
 -endif.

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -201,14 +201,22 @@ append_to_response_body(Data, RD=#wm_reqdata{resp_body=RespB}) ->
     end.
 
 get_cookie_value(Key, RD) when is_list(Key) -> % string
-    proplists:get_value(Key, req_cookie(RD)).
+    case lists:keyfind(Key, 1, req_cookie(RD)) of
+        false -> undefined;
+        {Key, Value} -> Value
+    end.
 
 get_qs_value(Key, RD) when is_list(Key) -> % string
-    proplists:get_value(Key, req_qs(RD)).
+    case lists:keyfind(Key, 1, req_qs(RD)) of
+        false -> undefined;
+        {Key, Value} -> Value
+    end.
 
 get_qs_value(Key, Default, RD) when is_list(Key) ->
-    proplists:get_value(Key, req_qs(RD), Default).
-
+    case lists:keyfind(Key, 1, req_qs(RD)) of
+        false -> Default;
+        {Key, Value} -> Value
+    end.
 add_note(K, V, RD) -> RD#wm_reqdata{notes=[{K, V} | RD#wm_reqdata.notes]}.
 
 get_notes(RD) -> RD#wm_reqdata.notes.


### PR DESCRIPTION
Hi,

This branch adds a convenience function wrq:base_uri to make it easier for implementors who want to include a URI in a generated response.

It also addresses an issue with the base_uri recently added to set the location header and teaches the dispatch code to use 443 as the default port for https.
- seth
