### PR TITLE
Redirection support via rewrite_module configuration option

### DIFF
--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -37,10 +37,15 @@ stop() ->
     application:stop(webmachine).
 
 new_request(mochiweb, Request) ->
+    RawPath = case application:get_env(webmachine, rewrite_module) of
+        {ok, RewriteMod} ->
+            RewriteMod:rewrite(Request:get(headers), Request:get(raw_path));
+        undefined ->
+            Request:get(raw_path)
+    end,
     Socket = Request:get(socket),
     Method = Request:get(method),
     Scheme = Request:get(scheme),
-    RawPath = Request:get(raw_path), 
     Version = Request:get(version),
     Headers = Request:get(headers),
     InitState = #wm_reqstate{socket=Socket,
@@ -63,4 +68,4 @@ new_request(mochiweb, Request) ->
 
 
 
-  
+

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -56,7 +56,15 @@ start(Options) ->
     end,
     application_set_unless_env(webmachine, dispatch_list, DispatchList),
     application_set_unless_env(webmachine, error_handler, ErrorHandler),
-    application_set_unless_env(webmachine, rewrite_module, RewriteModule),
+    case RewriteModule of
+        undefined ->
+            %% webmachine:new_request/2 will explode if
+            %% application:get_env returns {ok, undefined}
+            ok;
+        _ ->
+            application_set_unless_env(
+              webmachine, rewrite_module, RewriteModule)
+    end,
     mochiweb_http:start([{name, PName}, {loop, fun loop/1} | Options6]).
 
 stop() ->

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -24,13 +24,14 @@ start(Options) ->
     {DispatchList, Options1} = get_option(dispatch, Options),
     {ErrorHandler0, Options2} = get_option(error_handler, Options1),
     {EnablePerfLog, Options3} = get_option(enable_perf_logger, Options2),
+    {RewriteModule, Options4} = get_option(rewrite_module, Options3),
     ErrorHandler =
         case ErrorHandler0 of
             undefined ->
                 webmachine_error_handler;
             EH -> EH
         end,
-    {LogDir, Options4} = get_option(log_dir, Options3),
+    {LogDir, Options5} = get_option(log_dir, Options4),
     case whereis(webmachine_logger) of
       undefined ->
         webmachine_sup:start_logger(LogDir);
@@ -49,13 +50,14 @@ start(Options) ->
         _ ->
             ignore
     end,
-    {PName, Options5} = case get_option(name, Options4) of
-      {undefined, _} -> {?MODULE, Options4};
-      {PN, O5} -> {PN, O5}
+    {PName, Options6} = case get_option(name, Options5) of
+      {undefined, _} -> {?MODULE, Options5};
+      {PN, O6} -> {PN, O6}
     end,
     application_set_unless_env(webmachine, dispatch_list, DispatchList),
     application_set_unless_env(webmachine, error_handler, ErrorHandler),
-    mochiweb_http:start([{name, PName}, {loop, fun loop/1} | Options5]).
+    application_set_unless_env(webmachine, rewrite_module, RewriteModule),
+    mochiweb_http:start([{name, PName}, {loop, fun loop/1} | Options6]).
 
 stop() ->
     {registered_name, PName} = process_info(self(), registered_name),
@@ -70,7 +72,7 @@ loop(MochiReq) ->
            end,
     {Path, _} = Req:path(),
     {RD, _} = Req:get_reqdata(),
-
+    
     %% Run the dispatch code, catch any errors...
     try webmachine_dispatcher:dispatch(Host, Path, DispatchList, RD) of
         {no_dispatch_match, _UnmatchedHost, _UnmatchedPathTokens} ->


### PR DESCRIPTION
Basic support for path redirection via a {webmachine, rewrite_module} configuration option:

rewrite_module should export a single function, rewrite/2 with the following signature:

rewrite(Headers::mochiweb_headers(), Path::string()) -> NewPath::string().
