### PR TITLE
Fix support for media types with parameters

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -527,8 +527,6 @@ decision(v3o18) ->
                            httpd_util:rfc1123_date(
                               calendar:universal_time_to_local_time(Exp))})
             end,
-            F = hd([Fun || {Type,Fun} <- resource_call(content_types_provided),
-                           CT =:= Type]),
             FunL = lists:foldl(
                      fun({{Type, Params}, Fun}, AccIn) ->
                              case webmachine_util:format_content_type(Type, Params) =:= CT of

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -529,6 +529,16 @@ decision(v3o18) ->
             end,
             F = hd([Fun || {Type,Fun} <- resource_call(content_types_provided),
                            CT =:= Type]),
+            FunL = lists:foldl(
+                     fun({{Type, Params}, Fun}, AccIn) ->
+                             case webmachine_util:format_content_type(Type, Params) =:= CT of
+                                 true -> [Fun|AccIn];
+                                 false -> AccIn
+                             end;
+                        ({Type, Fun}, AccIn) when Type =:= CT -> [Fun|AccIn];
+                        (_, AccIn) -> AccIn
+                     end, [], resource_call(content_types_provided)),
+            F = hd(lists:reverse(FunL)),
             resource_call(F);
         false -> nop
     end,

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -23,6 +23,7 @@
 -export([choose_media_type/2]).
 -export([choose_charset/2]).
 -export([choose_encoding/2]).
+-export([format_content_type/2]).
 -export([now_diff_milliseconds/2]).
 -export([media_type_to_detail/1,
          quoted_string/1,
@@ -192,6 +193,7 @@ normalize_provided1(Type) when is_list(Type) -> {Type, []};
 normalize_provided1({Type,Params}) -> {Type, Params}.
 
 format_content_type(Type,[]) -> Type;
+format_content_type(Type,[{K,V}|T]) -> format_content_type(Type ++ "; " ++ K ++ "=" ++ V, T);
 format_content_type(Type,[H|T]) -> format_content_type(Type ++ "; " ++ H, T).
 
 choose_charset(CSets, AccCharHdr) -> do_choose(CSets, AccCharHdr, "ISO-8859-1").


### PR DESCRIPTION
Using media types with parameters ("audio/vnd.wave; codec=31" for example) does not work. These commits will fix that, at least for GET requests.
