### PR TITLE
Custom Server header support

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -682,7 +682,10 @@ make_headers(Code, Length, RD) ->
                       mochiweb_headers:make(wrq:resp_headers(RD)))
             end
     end,
-    ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")",
+    case application:get_env(webmachine, server_name) of
+      undefined -> ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")";
+      {ok, ServerHeader} when is_list(ServerHeader) -> ok
+    end,
     WithSrv = mochiweb_headers:enter("Server", ServerHeader, Hdrs0),
     Hdrs = case mochiweb_headers:get_value("date", WithSrv) of
         undefined ->


### PR DESCRIPTION
The idea behind this extension is that in some cases it is worthwhile to
obscure the actual server name (for example, for an extra layer of
attack protection) or change it any other way.

Of course this is doable with some HTTP proxies such as nginx. However,
in case of nginx (for example) one needs to build it with a custom
third-party module, which complicates the deployment insanely. Besides,
I believe there is a slight performance penalty when rewriting HTTP
headers. So, why not generate them the way you need them right from the
beginning?

This change allows setting custom server name by setting server_name
environment variable for webmachine application. By default, original
server name will be used.
