### PR TITLE
Slf fix media_type_to_detail

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -173,7 +173,7 @@ media_type_to_detail(MType) ->
     [CType|Params] = string:tokens(MType, ";"),
     MParams = [list_to_tuple([string:strip(KV) || KV <- string:tokens(X,"=")])
                 || X <- Params],
-    {CType, MParams}.                       
+    {string:strip(CType), MParams}.
 
 accept_header_to_media_types(HeadVal) ->
     % given the value of an accept header, produce an ordered list


### PR DESCRIPTION
Strip whitespace from content-type (and others) parsed by `webmachine_util.erl:media_type_to_detail/1`.
Without this fix, Webmachine cannot handle this (AFAICT completely RFC 2616 compliant) header:

```
content-type:          application/x-www-form-urlencoded          ;      charset      =       utf8
```
