### PR TITLE
Do not exit when mochiweb_socket:send returns an error

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -261,27 +261,31 @@ get_outheader_value(K) ->
       wrq:resp_headers(ReqState#wm_reqstate.reqdata)), ReqState}.
 
 send(Socket, Data) ->
-    case mochiweb_socket:send(Socket, iolist_to_binary(Data)) of
-        ok -> ok;
-        {error,closed} -> ok;
-        _ -> exit(normal)
-    end.
+    mochiweb_socket:send(Socket, iolist_to_binary(Data)).
 
 send_stream_body(Socket, X) -> send_stream_body(Socket, X, 0).
 send_stream_body(Socket, {<<>>, done}, SoFar) ->
     send_chunk(Socket, <<>>),
     SoFar;
 send_stream_body(Socket, {Data, done}, SoFar) ->
-    Size = send_chunk(Socket, Data),
-    send_chunk(Socket, <<>>),
-    Size + SoFar;
+    case send_chunk(Socket, Data) of
+        {error, _Reason} ->
+            SoFar;
+        Size ->
+            send_chunk(Socket, <<>>),
+            Size + SoFar
+    end;
 send_stream_body(Socket, {<<>>, Next}, SoFar) ->
     send_stream_body(Socket, Next(), SoFar);
 send_stream_body(Socket, {[], Next}, SoFar) ->
     send_stream_body(Socket, Next(), SoFar);
 send_stream_body(Socket, {Data, Next}, SoFar) ->
-    Size = send_chunk(Socket, Data),
-    send_stream_body(Socket, Next(), Size + SoFar).
+    case send_chunk(Socket, Data) of
+        {error, _Reason} ->
+            SoFar;
+        Size ->
+            send_stream_body(Socket, Next(), Size + SoFar)
+    end.
 
 send_writer_body(Socket, {Encoder, Charsetter, BodyFun}) ->
     put(bytes_written, 0),
@@ -296,11 +300,13 @@ send_writer_body(Socket, {Encoder, Charsetter, BodyFun}) ->
 
 send_chunk(Socket, Data) ->
     Size = iolist_size(Data),
-    send(Socket, mochihex:to_hex(Size)),
-    send(Socket, <<"\r\n">>),
-    send(Socket, Data),
-    send(Socket, <<"\r\n">>),
-    Size.
+    Chunk = [mochihex:to_hex(Size),<<"\r\n">>,Data,<<"\r\n">>],
+    case send(Socket, Chunk) of
+        ok ->
+            Size;
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 send_ok_response() ->
     RD0 = ReqState#wm_reqstate.reqdata,


### PR DESCRIPTION
This patch fixes issue #59.  Instead of exiting `normal` when `mochiweb_socket:send/2` does not return `ok`, this patch:
1. For non-streamed responses, simply returns success.
2. For streamed responses, halts further production of the stream, and returns the number of bytes sent so far.

The assumption is that an error from `mochiweb_socket:send/2` means that there was something wrong with the socket, not with our resource, and that that error will still be there when/if mochiweb attempts to read from it for the next request in the pipeline.  Returning success here allows the request to be recorded by the access logger.
