### PR TITLE
Do not exit when mochiweb_socket:send returns an error (Known-size-stream branch)

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -262,27 +262,31 @@ get_outheader_value(K) ->
       wrq:resp_headers(ReqState#wm_reqstate.reqdata)), ReqState}.
 
 send(Socket, Data) ->
-    case mochiweb_socket:send(Socket, iolist_to_binary(Data)) of
-        ok -> ok;
-        {error,closed} -> ok;
-        _ -> exit(normal)
-    end.
+    mochiweb_socket:send(Socket, iolist_to_binary(Data)).
 
 send_stream_body(Socket, X) -> send_stream_body(Socket, X, 0).
 send_stream_body(Socket, {<<>>, done}, SoFar) ->
     send_chunk(Socket, <<>>),
     SoFar;
 send_stream_body(Socket, {Data, done}, SoFar) ->
-    Size = send_chunk(Socket, Data),
-    send_chunk(Socket, <<>>),
-    Size + SoFar;
+    case send_chunk(Socket, Data) of
+        {error, _Reason} ->
+            SoFar;
+        Size ->
+            send_chunk(Socket, <<>>),
+            Size + SoFar
+    end;
 send_stream_body(Socket, {<<>>, Next}, SoFar) ->
     send_stream_body(Socket, Next(), SoFar);
 send_stream_body(Socket, {[], Next}, SoFar) ->
     send_stream_body(Socket, Next(), SoFar);
 send_stream_body(Socket, {Data, Next}, SoFar) ->
-    Size = send_chunk(Socket, Data),
-    send_stream_body(Socket, Next(), Size + SoFar).
+    case send_chunk(Socket, Data) of
+        {error, _Reason} ->
+            SoFar;
+        Size ->
+            send_stream_body(Socket, Next(), Size + SoFar)
+    end.
 
 send_stream_body_no_chunk(Socket, {Data, done}) ->
     send(Socket, Data);
@@ -303,11 +307,13 @@ send_writer_body(Socket, {Encoder, Charsetter, BodyFun}) ->
 
 send_chunk(Socket, Data) ->
     Size = iolist_size(Data),
-    send(Socket, mochihex:to_hex(Size)),
-    send(Socket, <<"\r\n">>),
-    send(Socket, Data),
-    send(Socket, <<"\r\n">>),
-    Size.
+    Chunk = [mochihex:to_hex(Size),<<"\r\n">>,Data,<<"\r\n">>],
+    case send(Socket, Chunk) of
+        ok ->
+            Size;
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 send_ok_response() ->
     RD0 = ReqState#wm_reqstate.reqdata,


### PR DESCRIPTION
This patch fixes issue #59.

Please see https://github.com/basho/webmachine/pull/62 for more information.  This patch is a rebased version of that one, with the same fix applied to the `known_size_stream` body producer.
