### PR TITLE
Various Media Range Params Fixes

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -528,7 +528,7 @@ decision(v3o18) ->
                               calendar:universal_time_to_local_time(Exp))})
             end,
             F = hd([Fun || {Type,Fun} <- resource_call(content_types_provided),
-                           CT =:= Type]),
+                           CT =:= webmachine_util:format_content_type(Type)]),
             resource_call(F);
         false -> nop
     end,

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -398,6 +398,14 @@ choose_media_type_qval_test() ->
     [ ?assertEqual("image/jpeg", choose_media_type(Provided, I))
       || I <- JpgMatch ].
 
+format_content_type_test() ->
+    Types = ["audio/vnd.wave; codec=31",
+             "Text/x-Okie; charset=iso-8859-1; declaration=\"<f950118.AEB0@XIson.com>\""],
+    [?assertEqual(Type, format_content_type(
+                          webmachine_util:media_type_to_detail(Type)))
+     || Type <- Types],
+    ?assertEqual(hd(Types), format_content_type("audio/vnd.wave", [{codec, "31"}])).
+
 convert_request_date_test() ->
     ?assertMatch({{_,_,_},{_,_,_}},
                  convert_request_date("Wed, 30 Dec 2009 14:39:02 GMT")),

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -20,7 +20,7 @@
 -module(webmachine_util).
 -export([guess_mime/1]).
 -export([convert_request_date/1, compare_ims_dates/2]).
--export([choose_media_type/2]).
+-export([choose_media_type/2, format_content_type/1]).
 -export([choose_charset/2]).
 -export([choose_encoding/2]).
 -export([now_diff_milliseconds/2]).
@@ -231,13 +231,16 @@ normalize_media_params([H|T], Acc) ->
 
     
 
+format_content_type(Type) when is_list(Type) ->
+    Type;
+format_content_type({Type,Params}) ->
+    format_content_type(Type,Params).
+
 format_content_type(Type,[]) -> Type;
-format_content_type(Type,[H|T]) -> 
-    P = case H of 
-	    {K,V} -> K ++ "=" ++ V;
-	    _ -> H
-	end,
-    format_content_type(Type ++ "; " ++ P, T).
+format_content_type(Type,[{K,V}|T]) when is_atom(K) -> 
+    format_content_type(Type, [{atom_to_list(K),V}|T]);
+format_content_type(Type,[{K,V}|T]) -> 
+    format_content_type(Type ++ "; " ++ K ++ "=" ++ V, T).
 
 choose_charset(CSets, AccCharHdr) -> do_choose(CSets, AccCharHdr, "ISO-8859-1").
 

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -217,7 +217,19 @@ accept_header_to_media_types(HeadVal) ->
 normalize_provided(Provided) ->
     [normalize_provided1(X) || X <- Provided].
 normalize_provided1(Type) when is_list(Type) -> {Type, []};
-normalize_provided1({Type,Params}) -> {Type, Params}.
+normalize_provided1({Type,Params}) -> {Type, normalize_media_params(Params)}.
+
+normalize_media_params(Params) ->
+    normalize_media_params(Params,[]).
+
+normalize_media_params([],Acc) ->
+    Acc;
+normalize_media_params([{K,V}|T], Acc) when is_atom(K) ->
+    normalize_media_params(T,[{atom_to_list(K),V}|Acc]);
+normalize_media_params([H|T], Acc) ->
+    normalize_media_params(T, [H|Acc]).
+
+    
 
 format_content_type(Type,[]) -> Type;
 format_content_type(Type,[H|T]) -> 

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -220,7 +220,12 @@ normalize_provided1(Type) when is_list(Type) -> {Type, []};
 normalize_provided1({Type,Params}) -> {Type, Params}.
 
 format_content_type(Type,[]) -> Type;
-format_content_type(Type,[H|T]) -> format_content_type(Type ++ "; " ++ H, T).
+format_content_type(Type,[H|T]) -> 
+    P = case H of 
+	    {K,V} -> K ++ "=" ++ V;
+	    _ -> H
+	end,
+    format_content_type(Type ++ "; " ++ P, T).
 
 choose_charset(CSets, AccCharHdr) -> do_choose(CSets, AccCharHdr, "ISO-8859-1").
 


### PR DESCRIPTION
This follows up on a bug originally adressed by this pull request https://github.com/basho/webmachine/pull/21 but that I don't think was ever completed from what I can tell (I haven't been able to find any other references and I was able to recreate the issues mentioned).

2 bug fixes and a minor "improvement":
- Fixes formatting of content types that contain parameters. Originally, this would cause webmachine to crash in certain cases
- fixing above caused webmachine to crash in v3o18 instead. this no longer occurs
- It was documented in `webmachine_util:choose_media_type/2` that atoms could be used as keys in the media-types params list, this is now supported.
