### PR TITLE
Fix dialyzer warnings for webmachine_request:port_string()

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -812,12 +812,12 @@ log_data() -> call(log_data).
 
 port_string(Scheme, Port) ->
     case Scheme of
-        http ->
+        "http" ->
             case Port of
                 80 -> "";
                 _ -> ":" ++ erlang:integer_to_list(Port)
             end;
-        https ->
+        "https" ->
             case Port of
                 443 -> "";
                 _ -> ":" ++ erlang:integer_to_list(Port)


### PR DESCRIPTION
Fixes two bugs:

```
% git branch | egrep '\*'
* master

% git log | head -1
commit 656aa69c6c6afd79d3446fd13c4f3bb3ba253ce5

% dialyzer -Wno_return ebin/*beam deps/*/ebin/*beam
  Checking whether the PLT /Users/fritchie/.dialyzer_plt is up-to-date... yes
  Compiling some key modules to native code... done in 0m21.94s
  Proceeding with analysis...
webmachine_request.erl:815: The pattern 'http' can never match the type string()
webmachine_request.erl:820: The pattern 'https' can never match the type string()
Unknown functions:
  compile:forms/2
  fdsrv:bind_socket/2
  fdsrv:start/0
  fdsrv:stop/0
 done in 0m15.44s
done (warnings were emitted)
```
