### PR TITLE
App skeleton priv dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 deps/*
 *.beam
+.eunit/*

--- a/priv/templates/src/wmskel_sup.erl
+++ b/priv/templates/src/wmskel_sup.erl
@@ -42,9 +42,9 @@ upgrade() ->
 %% @doc supervisor callback.
 init([]) ->
     Ip = case os:getenv("WEBMACHINE_IP") of false -> "0.0.0.0"; Any -> Any end,
-    {ok, Dispatch} = file:consult(filename:join(
-                         [filename:dirname(code:which(?MODULE)),
-                          "..", "priv", "dispatch.conf"])),
+    {ok, App} = application:get_application(?MODULE),
+    {ok, Dispatch} = file:consult(filename:join([code:priv_dir(App),
+                                                 "dispatch.conf"])),
     WebConfig = [
                  {ip, Ip},
                  {port, 8000},


### PR DESCRIPTION
This changes how the application priv directory is found in the application skeleton code. It now uses code:priv_dir instead of creating a priv dir pathname relative to the ebin directory.

The second commit just adds the .eunit dir to .gitignore.
