### PR TITLE
Properly filter per-host dispatches in webmachine_router:remove_resource/1

### DIFF
--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -186,11 +186,27 @@ add_remove_resource_test() ->
     PathSpec1 = {["foo"], foo, []},
     PathSpec2 = {["bar"], foo, []},
     PathSpec3 = {["baz"], bar, []},
+    PathSpec4 = {["foo"], fun(_) -> true end, foo, []},
+    PathSpec5 = {["foo"], {webmachine_router, test_guard}, foo, []},
     webmachine_router:add_route(PathSpec1),
     webmachine_router:add_route(PathSpec2),
     webmachine_router:add_route(PathSpec3),
     webmachine_router:remove_resource(foo),
     [PathSpec3] = get_routes(),
+    webmachine_router:add_route(PathSpec4),
+    webmachine_router:remove_resource(foo),
+    [PathSpec3] = get_routes(),
+    webmachine_router:add_route(PathSpec5),
+    webmachine_router:remove_resource(foo),
+    [PathSpec3] = get_routes(),
+    webmachine_router:remove_route(PathSpec3),
+    [begin
+         PathSpec = {"localhost", [HostPath]},
+         webmachine_router:add_route(PathSpec),
+         webmachine_router:remove_resource(foo),
+         [{"localhost", []}] = get_routes(),
+         webmachine_router:remove_route({"localhost", []})
+     end || HostPath <- [PathSpec1, PathSpec4, PathSpec5]],
     exit(Pid, kill).
 
 no_dupe_path_test() ->

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -95,8 +95,7 @@ handle_call(get_routes, _From, State) ->
     {reply, get_dispatch_list(), State};
 
 handle_call({remove_resource, Resource}, _From, State) ->
-    DL = [D || D <- get_dispatch_list(),
-               filter_by_resource(D, Resource)],
+    DL = filter_by_resource(Resource, get_dispatch_list()),
     {reply, set_dispatch_list(DL), State};
 
 handle_call({remove_route, Route}, _From, State) ->
@@ -129,22 +128,21 @@ code_change(_OldVsn, State, _Extra) ->
   {ok, State}.
 
 %% Internal functions
-filter_by_resource({_, {_, Resource, _}}, Resource) ->
-    false;
-filter_by_resource({_, {_, _, _}}, _Resource) ->
-    true;
-filter_by_resource({_, Resource, _}, Resource) ->
-    false;
-filter_by_resource({_, _, _}, _Resource) ->
-    true;
-filter_by_resource({_,_,Resource,_}, Resource) ->
-    false;
-filter_by_resource({_,_,_,_}, _Resource) ->
-    true;
-filter_by_resource({_,{_,_,Resource,_}}, Resource) ->
-    false;
-filter_by_resource({_,{_,_,_,_}}, _Resource) ->
-    true.
+
+%% @doc Remove any dispatch rule that directs requests to `Resource'
+filter_by_resource(Resource, Dispatch) ->
+    lists:foldr(filter_by_resource(Resource), [], Dispatch).
+
+filter_by_resource(Resource) ->
+    fun({_, R, _}, Acc) when R == Resource -> % basic dispatch
+            Acc;
+       ({_, _, R, _}, Acc) when R == Resource -> % guarded dispatch
+            Acc;
+       ({Host, Disp}, Acc) -> % host-based dispatch
+            [{Host, filter_by_resource(Resource, Disp)}|Acc];
+       (Other, Acc) -> % dispatch not mentioning this resource
+            [Other|Acc]
+    end.
 
 get_dispatch_list() ->
     case application:get_env(webmachine, dispatch_list) of


### PR DESCRIPTION
It looks like webmachine_router:remove_resource/1 never worked on
host-based dispatch lines because it was attempting to match {Host,
Path}, instead of {Host, [Path, ...]}.  This patch changes the filter to
delve into those per-host dispatch lists to apply the filter correctly
there as well.
