### PR TITLE
Add logging for when webmachine crashes and body exists.

### DIFF
--- a/src/webmachine_error_handler.erl
+++ b/src/webmachine_error_handler.erl
@@ -27,7 +27,9 @@
 
 render_error(Code, Req, Reason) ->
     case Req:has_response_body() of
-        {true,_} -> Req:response_body();
+        {true,_} ->
+            maybe_log(Req, Reason),
+            Req:response_body();
         {false,_} -> render_error_body(Code, Req:trim_state(), Reason)
     end.
 
@@ -37,16 +39,7 @@ render_error_body(404, Req, _Reason) ->
 
 render_error_body(500, Req, Reason) ->
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
-    {Path,_} = Req:path(),
-    case Reason of
-        {error, {exit, normal, _Stack}} ->
-            %% webmachine_request did an exit(normal), so suppress this
-            %% message. This usually happens when a chunked upload is
-            %% interrupted by network failure.
-            ok;
-        _ ->
-            error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, Reason])
-    end,
+    maybe_log(Req, Reason),
     STString = io_lib:format("~p", [Reason]),
     ErrorStart = "<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>",
     ErrorEnd = "</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>",
@@ -79,3 +72,11 @@ render_error_body(503, Req, _Reason) ->
                "</ADDRESS></body></html>",
     {list_to_binary(ErrorStr), ReqState}.
 
+maybe_log(_Req, {error, {exit, normal, _Stack}}) ->
+    %% webmachine_request did an exit(normal), so suppress this
+    %% message. This usually happens when a chunked upload is
+    %% interrupted by network failure.
+    ok;
+maybe_log(Req, Reason) ->
+    {Path,_} = Req:path(),
+    error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, Reason]).


### PR DESCRIPTION
We get lots of crashes when clients try to get chunked delivery, but webmachine swallows those errors. We can see the return code is 500 but nothing the error logs, since there is no logging if there already is a response body.

This commit adds logging on internal errors that has a body. Refactored out the case to a pattern
match as well.
