### PR TITLE
Incorrect accept header in some blackberry devices.

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -26,7 +26,8 @@
 -export([now_diff_milliseconds/2]).
 -export([media_type_to_detail/1,
          quoted_string/1,
-         split_quoted_strings/1]).
+         split_quoted_strings/1
+	]).
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -186,6 +187,8 @@ prioritize_media(Type,Params,Acc) ->
                     QVal = case Val of
                                "1" ->
                                    1;
+				"0" ->
+				   0;
                                [$.|_] ->
                                    %% handle strange FeedBurner Accept
                                    list_to_float([$0|Val]); 


### PR DESCRIPTION
Hello, 

In some blackberry devices ( problaby due locale issues)  the following incorrect accept header   appears:

"text/html,application/xhtml+xml,application/xml,application/x-javascript,_/_;q=0,5"

The "q" comes from device with a ',' instead of '.'.

Regards.
