### PR TITLE
remove code:clash call

### DIFF
--- a/src/webmachine_deps.erl
+++ b/src/webmachine_deps.erl
@@ -57,7 +57,6 @@ new_siblings(Module) ->
 %%      of the application for Module are on the code path.
 ensure(Module) ->
     code:add_paths(new_siblings(Module)),
-    code:clash(),
     ok.
 
 %% @spec ensure() -> ok


### PR DESCRIPTION
Does anyone derive use from this call?  It's the one that's responsible for log messages like:

```
** /Users/bryan/work/pmi2/riak_pipe/.eunit/riak_pipe_sup.beam hides /Users/bryan/work/pmi2/riak/deps/riak_pipe/ebin/riak_pipe_sup.beam
```

I'd prefer to have less spam in my testing output. Anyone object?
