### PR TITLE
Fix the root of the reversed-location problem

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -48,8 +48,7 @@ dispatch(HostAsString, PathAsString, DispatchList, RD) ->
                      _ -> 0
                  end,
     {Host, Port} = split_host_port(HostAsString),
-    try_host_binding(DispatchList, lists:reverse(Host), Port,
-                     Path, ExtraDepth, RD).
+    try_host_binding(DispatchList, Host, Port, Path, ExtraDepth, RD).
 
 split_host_port(HostAsString) ->
     case string:tokens(HostAsString, ":") of
@@ -147,9 +146,14 @@ split_host(HostAsString) ->
 
 %% @type dispfail() = {no_dispatch_match, pathtokens()}.
 
-try_host_binding([], Host, Port, Path, _Depth, _RD) ->
-    {no_dispatch_match, {Host, Port}, Path};
-try_host_binding([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
+try_host_binding(Dispatch, Host, Port, Path, Depth, RD) ->
+    %% save work during each dispatch attempt by reversing Host up front
+    try_host_binding1(Dispatch, lists:reverse(Host), Port, Path, Depth, RD).
+
+try_host_binding1([], Host, Port, Path, _Depth, _RD) ->
+    %% Host was reversed inbound, correct it for result
+    {no_dispatch_match, {lists:reverse(Host), Port}, Path};
+try_host_binding1([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
     {{HostSpec,PortSpec},PathSpec} =
         case Dispatch of
             {{H,P},S} -> {{H,P},S};
@@ -159,20 +163,22 @@ try_host_binding([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
     case bind_port(PortSpec, Port, []) of
         {ok, PortBindings} ->
             case bind(lists:reverse(HostSpec), Host, PortBindings, 0) of
-                {ok, HostRemainder, HostBindings, _} ->
+                {ok, RevHostRemainder, HostBindings, _} ->
+                    %% Host was reversed inbound, correct it for remainder
+                    HostRemainder = lists:reverse(RevHostRemainder),
                     case try_path_binding(PathSpec, Path, HostRemainder, Port, HostBindings, Depth, RD) of
                         {Mod, Props, PathRemainder, PathBindings,
                          AppRoot, StringPath} ->
                             {Mod, Props, HostRemainder, Port, PathRemainder,
                              PathBindings, AppRoot, StringPath};
                         {no_dispatch_match, _} ->
-                            try_host_binding(Rest, Host, Port, Path, Depth, RD)
+                            try_host_binding1(Rest, Host, Port, Path, Depth, RD)
                     end;
                 fail ->
-                    try_host_binding(Rest, Host, Port, Path, Depth, RD)
+                    try_host_binding1(Rest, Host, Port, Path, Depth, RD)
             end;
         fail ->
-            try_host_binding(Rest, Host, Port, Path, Depth, RD)
+            try_host_binding1(Rest, Host, Port, Path, Depth, RD)
     end.
 
 bind_port(Port, Port, Bindings) -> {ok, Bindings};
@@ -418,13 +424,13 @@ try_host_binding_fullmatch_test() ->
                 {{['*',"bar"],'*'}, [{["d"],t,u}]}],
     ?assertEqual({x, y, [], 80, [], [], ".", ""},
                  try_host_binding(Dispatch,
-                                  ["bar","foo"], 80, ["a"], 0, RD)),
+                                  ["foo","bar"], 80, ["a"], 0, RD)),
     ?assertEqual({z, q, [], 80, [], [{foo,"baz"}], ".", ""},
                  try_host_binding(Dispatch,
-                                  ["bar","baz"], 80, ["b"], 0, RD)),
+                                  ["baz","bar"], 80, ["b"], 0, RD)),
     {Mod, Props, HostRemainder, Port, PathRemainder,
      PathBindings, AppRoot, StringPath}=
-        try_host_binding(Dispatch, ["bar","quux"], 1234, ["c"], 0, RD),
+        try_host_binding(Dispatch, ["quux","bar"], 1234, ["c"], 0, RD),
     ?assertEqual(r, Mod),
     ?assertEqual(s, Props),
     ?assertEqual("", HostRemainder),
@@ -435,8 +441,14 @@ try_host_binding_fullmatch_test() ->
     ?assertEqual(1234, proplists:get_value(baz, PathBindings)),
     ?assertEqual(".", AppRoot),
     ?assertEqual("", StringPath),
-    ?assertEqual({t, u, ["quux","foo"], 80, [], [], ".", ""},
-                 try_host_binding(Dispatch, ["bar","quux","foo"],80,["d"],0, RD)).
+    ?assertEqual({t, u, ["foo","quux"], 80, [], [], ".", ""},
+                 try_host_binding(Dispatch, ["foo","quux","bar"],80,["d"],0, RD)).
+
+try_host_binding_wildcard_token_order_test() ->
+    RD = testing,
+    Dispatch = [{{['*',"quux","com"],80},[{['*'],x,y}]}],
+    ?assertEqual({x,y,["foo","bar","baz"],80,[],[],".",""},
+                 dispatch("foo.bar.baz.quux.com","/",Dispatch,RD)).
 
 try_host_binding_fail_test() ->
     RD = testing,
@@ -460,7 +472,7 @@ dispatch_test() ->
     ?assertEqual({x, y, [], 1234, [], [], "../../..", ""},
                  dispatch("foo.bar:1234", "a/b/",
                           [{{["foo","bar"],1234},[{["a","b"],x,y}]}], RD)),
-    ?assertEqual({no_dispatch_match, {["bar","baz"],8000}, ["q","r"]},
+    ?assertEqual({no_dispatch_match, {["baz","bar"],8000}, ["q","r"]},
                  dispatch("baz.bar:8000", "q/r",
                           [{{["foo","bar"],80},[{["a","b","c"],x,y}]}], RD)).
 


### PR DESCRIPTION
That reversal is an implementation detail that never should have leaked out of the binding function.

I believe that this is the root fix for issue #35.

When this is merged, we also need to merge https://github.com/basho/riak_kv/pull/384 and https://github.com/basho/riak_control/pull/39 to address the issues that Reid raised https://github.com/basho/webmachine/pull/35#issuecomment-7789109
