### PR TITLE
Rebase of #46 to account for host token order correction

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -48,8 +48,7 @@ dispatch(HostAsString, PathAsString, DispatchList, RD) ->
                      _ -> 0
                  end,
     {Host, Port} = split_host_port(HostAsString),
-    try_host_binding(DispatchList, lists:reverse(Host), Port,
-                     Path, ExtraDepth, RD).
+    try_host_binding(DispatchList, Host, Port, Path, ExtraDepth, RD).
 
 split_host_port(HostAsString) ->
     case string:tokens(HostAsString, ":") of
@@ -147,9 +146,14 @@ split_host(HostAsString) ->
 
 %% @type dispfail() = {no_dispatch_match, pathtokens()}.
 
-try_host_binding([], Host, Port, Path, _Depth, _RD) ->
-    {no_dispatch_match, {Host, Port}, Path};
-try_host_binding([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
+try_host_binding(Dispatch, Host, Port, Path, Depth, RD) ->
+    %% save work during each dispatch attempt by reversing Host up front
+    try_host_binding1(Dispatch, lists:reverse(Host), Port, Path, Depth, RD).
+
+try_host_binding1([], Host, Port, Path, _Depth, _RD) ->
+    %% Host was reversed inbound, correct it for result
+    {no_dispatch_match, {lists:reverse(Host), Port}, Path};
+try_host_binding1([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
     {{HostSpec,PortSpec},PathSpec} =
         case Dispatch of
             {{H,P},S} -> {{H,P},S};
@@ -159,20 +163,22 @@ try_host_binding([Dispatch|Rest], Host, Port, Path, Depth, RD) ->
     case bind_port(PortSpec, Port, []) of
         {ok, PortBindings} ->
             case bind(lists:reverse(HostSpec), Host, PortBindings, 0) of
-                {ok, HostRemainder, HostBindings, _} ->
+                {ok, RevHostRemainder, HostBindings, _} ->
+                    %% Host was reversed inbound, correct it for remainder
+                    HostRemainder = lists:reverse(RevHostRemainder),
                     case try_path_binding(PathSpec, Path, HostRemainder, Port, HostBindings, Depth, RD) of
                         {Mod, Props, PathRemainder, PathBindings,
                          AppRoot, StringPath} ->
                             {Mod, Props, HostRemainder, Port, PathRemainder,
                              PathBindings, AppRoot, StringPath};
                         {no_dispatch_match, _} ->
-                            try_host_binding(Rest, Host, Port, Path, Depth, RD)
+                            try_host_binding1(Rest, Host, Port, Path, Depth, RD)
                     end;
                 fail ->
-                    try_host_binding(Rest, Host, Port, Path, Depth, RD)
+                    try_host_binding1(Rest, Host, Port, Path, Depth, RD)
             end;
         fail ->
-            try_host_binding(Rest, Host, Port, Path, Depth, RD)
+            try_host_binding1(Rest, Host, Port, Path, Depth, RD)
     end.
 
 bind_port(Port, Port, Bindings) -> {ok, Bindings};
@@ -418,13 +424,13 @@ try_host_binding_fullmatch_test() ->
                 {{['*',"bar"],'*'}, [{["d"],t,u}]}],
     ?assertEqual({x, y, [], 80, [], [], ".", ""},
                  try_host_binding(Dispatch,
-                                  ["bar","foo"], 80, ["a"], 0, RD)),
+                                  ["foo","bar"], 80, ["a"], 0, RD)),
     ?assertEqual({z, q, [], 80, [], [{foo,"baz"}], ".", ""},
                  try_host_binding(Dispatch,
-                                  ["bar","baz"], 80, ["b"], 0, RD)),
+                                  ["baz","bar"], 80, ["b"], 0, RD)),
     {Mod, Props, HostRemainder, Port, PathRemainder,
      PathBindings, AppRoot, StringPath}=
-        try_host_binding(Dispatch, ["bar","quux"], 1234, ["c"], 0, RD),
+        try_host_binding(Dispatch, ["quux","bar"], 1234, ["c"], 0, RD),
     ?assertEqual(r, Mod),
     ?assertEqual(s, Props),
     ?assertEqual("", HostRemainder),
@@ -435,8 +441,14 @@ try_host_binding_fullmatch_test() ->
     ?assertEqual(1234, proplists:get_value(baz, PathBindings)),
     ?assertEqual(".", AppRoot),
     ?assertEqual("", StringPath),
-    ?assertEqual({t, u, ["quux","foo"], 80, [], [], ".", ""},
-                 try_host_binding(Dispatch, ["bar","quux","foo"],80,["d"],0, RD)).
+    ?assertEqual({t, u, ["foo","quux"], 80, [], [], ".", ""},
+                 try_host_binding(Dispatch, ["foo","quux","bar"],80,["d"],0, RD)).
+
+try_host_binding_wildcard_token_order_test() ->
+    RD = testing,
+    Dispatch = [{{['*',"quux","com"],80},[{['*'],x,y}]}],
+    ?assertEqual({x,y,["foo","bar","baz"],80,[],[],".",""},
+                 dispatch("foo.bar.baz.quux.com","/",Dispatch,RD)).
 
 try_host_binding_fail_test() ->
     RD = testing,
@@ -460,7 +472,7 @@ dispatch_test() ->
     ?assertEqual({x, y, [], 1234, [], [], "../../..", ""},
                  dispatch("foo.bar:1234", "a/b/",
                           [{{["foo","bar"],1234},[{["a","b"],x,y}]}], RD)),
-    ?assertEqual({no_dispatch_match, {["bar","baz"],8000}, ["q","r"]},
+    ?assertEqual({no_dispatch_match, {["baz","bar"],8000}, ["q","r"]},
                  dispatch("baz.bar:8000", "q/r",
                           [{{["foo","bar"],80},[{["a","b","c"],x,y}]}], RD)).
 

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -122,11 +122,7 @@ x_peername(Default) ->
     end.
 
 call(base_uri) ->
-    RD = ReqState#wm_reqstate.reqdata,
-    Scheme = erlang:atom_to_list(RD#wm_reqdata.scheme),
-    Host = string:join(RD#wm_reqdata.host_tokens, "."),
-    PortString = port_string(Scheme, RD#wm_reqdata.port),
-    {Scheme ++ "://" ++ Host ++ PortString,ReqState};
+    {wrq:base_uri(ReqState#wm_reqstate.reqdata), ReqState};
 call(socket) -> {ReqState#wm_reqstate.socket,ReqState};
 call(get_reqdata) -> {ReqState#wm_reqstate.reqdata, ReqState};
 call({set_reqdata, RD}) -> {ok, ReqState#wm_reqstate{reqdata=RD}};
@@ -809,18 +805,3 @@ load_dispatch_data(Bindings, HostTokens, Port, PathTokens,
           PathTokens, AppRoot, DispPath}).
 
 log_data() -> call(log_data).
-
-port_string(Scheme, Port) ->
-    case Scheme of
-        "http" ->
-            case Port of
-                80 -> "";
-                _ -> ":" ++ erlang:integer_to_list(Port)
-            end;
-        "https" ->
-            case Port of
-                443 -> "";
-                _ -> ":" ++ erlang:integer_to_list(Port)
-            end;
-        _ -> ":" ++ erlang:integer_to_list(Port)
-    end.


### PR DESCRIPTION
This is just a rebase of #46 on top of the bwf-pr35 branch, to clean up the merges and to account for the correction of `host_tokens` order.
