### PR TITLE
change parameterized modules to regular modules

### DIFF
--- a/include/wm_resource.hrl
+++ b/include/wm_resource.hrl
@@ -1,0 +1,1 @@
+-record(wm_resource, {module, modstate, modexports, trace}).

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -1,6 +1,6 @@
 %% @author Justin Sheehy <justin@basho.com>
 %% @author Andy Gross <andy@basho.com>
-%% @copyright 2007-2009 Basho Technologies
+%% @copyright 2007-2012 Basho Technologies
 %% Based on mochiweb_request.erl, which is Copyright 2007 Mochi Media, Inc.
 %%
 %%    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,64 +15,85 @@
 %%    See the License for the specific language governing permissions and
 %%    limitations under the License.
 
-%% @doc Webmachine HTTP Request Abstraction.
+%% @doc Webmachine HTTP Request Abstraction. The functions in this module
+%% can be invoked using either parameterized module syntax or regular
+%% invocation syntax. Since the Ericsson OTP team is removing the
+%% parameterized module syntax in version R16, we encourage you to write
+%% your applications using regular function syntax.
+%%
+%% To use parameterized module syntax, you create an instance and then
+%% invoke functions on that instance, like this:
+%%
+%% <pre><code>
+%%   Req = webmachine_request:new(ReqState),
+%%   Result = Req:some_fun(Args),
+%% </code></pre>
+%%
+%% where `ReqState' is an instance of a `#wm_reqstate' record. The runtime
+%% then ensures the `ReqState' variable is implicitly passed to each
+%% function invoked through the `Req' instance.
+%%
+%% To call functions using regular syntax, simply explicitly pass the
+%% `ReqState' variable yourself; note there's no need to call
+%% `webmachine_request:new/1' to perform regular invocations.
 
--module(webmachine_request, [ReqState]).
+-module(webmachine_request).
 -author('Justin Sheehy <justin@basho.com>').
 -author('Andy Gross <andy@basho.com>').
 
--export([get_peer/0]). % used in initialization
--export([call/1]). % internal switching interface, used by wrcall
+-export([get_peer/1]). % used in initialization
+-export([call/2]). % internal switching interface, used by wrcall
 
 % actual interface for resource functions
 -export([
-         trim_state/0,
-         get_reqdata/0,
-         set_reqdata/1,
-         socket/0,
-         method/0,
-         version/0,
-         disp_path/0,
-         path/0,
-         raw_path/0,
-         get_req_header/1,
-         req_headers/0,
-         req_body/1,
-         stream_req_body/1,
-         headers/0,
-         resp_headers/0,
-         out_headers/0,
-         get_out_header/1,
-         has_out_header/1,
-         peer/0,
-         get_header_value/1,
-         add_response_header/2,
-         add_response_headers/1,
-         remove_response_header/1,
-         merge_response_headers/1,
-         append_to_response_body/1,
-         send_response/1,
-         response_code/0,
-         set_response_code/1,
-         set_resp_body/1,
-         response_body/0,
-         has_response_body/0,
-         do_redirect/0,
-         resp_redirect/0,
-         set_metadata/2,
-         get_metadata/1,
-         get_path_info/0,
+         new/1,
+         trim_state/1,
+         get_reqdata/1,
+         set_reqdata/2,
+         socket/1,
+         method/1,
+         version/1,
+         disp_path/1,
+         path/1,
+         raw_path/1,
+         get_req_header/2,
+         req_headers/1,
+         req_body/2,
+         stream_req_body/2,
+         headers/1,
+         resp_headers/1,
+         out_headers/1,
+         get_out_header/2,
+         has_out_header/2,
+         peer/1,
+         get_header_value/2,
+         add_response_header/3,
+         add_response_headers/2,
+         remove_response_header/2,
+         merge_response_headers/2,
+         append_to_response_body/2,
+         send_response/2,
+         response_code/1,
+         set_response_code/2,
+         set_resp_body/2,
+         response_body/1,
+         has_response_body/1,
+         do_redirect/1,
+         resp_redirect/1,
+         set_metadata/3,
+         get_metadata/2,
          get_path_info/1,
-         load_dispatch_data/6,
-         get_path_tokens/0,
-         get_app_root/0,
-         parse_cookie/0,
-         get_cookie_value/1,
-         parse_qs/0,
-         get_qs_value/1,
+         get_path_info/2,
+         load_dispatch_data/7,
+         get_path_tokens/1,
+         get_app_root/1,
+         parse_cookie/1,
+         get_cookie_value/2,
+         parse_qs/1,
          get_qs_value/2,
-         range/0,
-         log_data/0
+         get_qs_value/3,
+         range/1,
+         log_data/1
         ]).
 
 -include("webmachine_logger.hrl").
@@ -83,11 +104,16 @@
 -define(QUIP, "someone had painted it blue").
 -define(IDLE_TIMEOUT, infinity).
 
-trim_state() ->
-    TrimData = (ReqState#wm_reqstate.reqdata)#wm_reqdata{wm_state='WMSTATE'},
-    webmachine_request:new(ReqState#wm_reqstate{reqdata=TrimData}).
+new(#wm_reqstate{}=ReqState) ->
+    {?MODULE, ReqState}.
 
-get_peer() ->
+trim_state({?MODULE, ReqState}) ->
+    TrimData = (ReqState#wm_reqstate.reqdata)#wm_reqdata{wm_state='WMSTATE'},
+    webmachine_request:new(ReqState#wm_reqstate{reqdata=TrimData});
+trim_state(ReqState) ->
+    trim_state({?MODULE, ReqState}).
+
+get_peer({?MODULE, ReqState}=Req) ->
     case ReqState#wm_reqstate.peer of
     undefined ->
         PeerName = case ReqState#wm_reqstate.socket of
@@ -95,42 +121,50 @@ get_peer() ->
             {ssl,SslSocket} -> ssl:peername(SslSocket);
             _ -> inet:peername(ReqState#wm_reqstate.socket)
         end,
-        Peer = peer_from_peername(PeerName),
+        Peer = peer_from_peername(PeerName, Req),
         NewReqState = ReqState#wm_reqstate{peer=Peer},
         {Peer, NewReqState};
     _ ->
         {ReqState#wm_reqstate.peer, ReqState}
-    end.
+    end;
+get_peer(ReqState) ->
+    get_peer({?MODULE, ReqState}).
 
-peer_from_peername({ok, {Addr={10, _, _, _}, _Port}}) ->  
-    x_peername(inet_parse:ntoa(Addr));
-peer_from_peername({ok, {Addr={172, Second, _, _}, _Port}}) when (Second > 15) andalso (Second < 32) ->
-    x_peername(inet_parse:ntoa(Addr));
-peer_from_peername({ok, {Addr={192, 168, _, _}, _Port}}) ->
-    x_peername(inet_parse:ntoa(Addr));
-peer_from_peername({ok, {{127, 0, 0, 1}, _Port}}) ->
-    x_peername("127.0.0.1");
-peer_from_peername({ok, {Addr, _Port}}) ->
+peer_from_peername({ok, {Addr={10, _, _, _}, _Port}}, Req) ->
+    x_peername(inet_parse:ntoa(Addr), Req);
+peer_from_peername({ok, {Addr={172, Second, _, _}, _Port}}, Req)
+  when (Second > 15) andalso (Second < 32) ->
+    x_peername(inet_parse:ntoa(Addr), Req);
+peer_from_peername({ok, {Addr={192, 168, _, _}, _Port}}, Req) ->
+    x_peername(inet_parse:ntoa(Addr), Req);
+peer_from_peername({ok, {{127, 0, 0, 1}, _Port}}, Req) ->
+    x_peername("127.0.0.1", Req);
+peer_from_peername({ok, {Addr, _Port}}, _Req) ->
     inet_parse:ntoa(Addr).
 
-x_peername(Default) ->
-    case get_header_value("x-forwarded-for") of
+x_peername(Default, Req) ->
+    case get_header_value("x-forwarded-for", Req) of
     {undefined, _} ->
         Default;
     {Hosts, _} ->
         string:strip(lists:last(string:tokens(Hosts, ",")))
     end.
 
-call(base_uri) ->
+call(base_uri, {?MODULE, ReqState}) ->
     {wrq:base_uri(ReqState#wm_reqstate.reqdata), ReqState};
-call(socket) -> {ReqState#wm_reqstate.socket,ReqState};
-call(get_reqdata) -> {ReqState#wm_reqstate.reqdata, ReqState};
-call({set_reqdata, RD}) -> {ok, ReqState#wm_reqstate{reqdata=RD}};
-call(method) -> {wrq:method(ReqState#wm_reqstate.reqdata), ReqState};
-call(version) -> {wrq:version(ReqState#wm_reqstate.reqdata), ReqState};
-call(raw_path) -> {wrq:raw_path(ReqState#wm_reqstate.reqdata), ReqState};
-call(req_headers) -> {wrq:req_headers(ReqState#wm_reqstate.reqdata), ReqState};
-call({req_body, MaxRecvBody}) ->
+call(socket, {?MODULE, ReqState}) -> {ReqState#wm_reqstate.socket,ReqState};
+call(get_reqdata, {?MODULE, ReqState}) -> {ReqState#wm_reqstate.reqdata, ReqState};
+call({set_reqdata, RD}, {?MODULE, ReqState}) ->
+    {ok, ReqState#wm_reqstate{reqdata=RD}};
+call(method, {?MODULE, ReqState}) ->
+    {wrq:method(ReqState#wm_reqstate.reqdata), ReqState};
+call(version, {?MODULE, ReqState}) ->
+    {wrq:version(ReqState#wm_reqstate.reqdata), ReqState};
+call(raw_path, {?MODULE, ReqState}) ->
+    {wrq:raw_path(ReqState#wm_reqstate.reqdata), ReqState};
+call(req_headers, {?MODULE, ReqState}) ->
+    {wrq:req_headers(ReqState#wm_reqstate.reqdata), ReqState};
+call({req_body, MaxRecvBody}, {?MODULE, ReqState}) ->
     case ReqState#wm_reqstate.bodyfetch of
         stream ->
             {stream_conflict, ReqState};
@@ -151,110 +185,122 @@ call({req_body, MaxRecvBody}) ->
             {NewBody, NewReqState#wm_reqstate{
                         bodyfetch=standard,reqdata=NewRD,reqbody=NewBody}}
     end;
-call({stream_req_body, MaxHunk}) ->
+call({stream_req_body, MaxHunk}, {?MODULE, ReqState}=Req) ->
     case ReqState#wm_reqstate.bodyfetch of
         standard ->
             {stream_conflict, ReqState};
         _ ->
-            {recv_stream_body(ReqState, MaxHunk),
+            {recv_stream_body(MaxHunk, Req),
              ReqState#wm_reqstate{bodyfetch=stream}}
     end;
-call(resp_headers) ->
+call(resp_headers, {?MODULE, ReqState}) ->
     {wrq:resp_headers(ReqState#wm_reqstate.reqdata), ReqState};
-call(resp_redirect) ->
+call(resp_redirect, {?MODULE, ReqState}) ->
     {wrq:resp_redirect(ReqState#wm_reqstate.reqdata), ReqState};
-call({get_resp_header, HdrName}) ->
+call({get_resp_header, HdrName}, {?MODULE, ReqState}) ->
     Reply = mochiweb_headers:get_value(HdrName,
                 wrq:resp_headers(ReqState#wm_reqstate.reqdata)),
     {Reply, ReqState};
-call(get_path_info) ->
+call(get_path_info, {?MODULE, ReqState}) ->
     PropList = dict:to_list(wrq:path_info(ReqState#wm_reqstate.reqdata)),
     {PropList, ReqState};
-call({get_path_info, Key}) ->
+call({get_path_info, Key}, {?MODULE, ReqState}) ->
     {wrq:path_info(Key, ReqState#wm_reqstate.reqdata), ReqState};
-call(peer) -> get_peer();
-call(range) -> get_range();
-call(response_code) ->
+call(peer, Req) -> get_peer(Req);
+call(range, Req) -> get_range(Req);
+call(response_code, {?MODULE, ReqState}) ->
     {wrq:response_code(ReqState#wm_reqstate.reqdata), ReqState};
-call(app_root) -> {wrq:app_root(ReqState#wm_reqstate.reqdata), ReqState};
-call(disp_path) -> {wrq:disp_path(ReqState#wm_reqstate.reqdata), ReqState};
-call(path) -> {wrq:path(ReqState#wm_reqstate.reqdata), ReqState};
-call({get_req_header, K}) ->
+call(app_root, {?MODULE, ReqState}) ->
+    {wrq:app_root(ReqState#wm_reqstate.reqdata), ReqState};
+call(disp_path, {?MODULE, ReqState}) ->
+    {wrq:disp_path(ReqState#wm_reqstate.reqdata), ReqState};
+call(path, {?MODULE, ReqState}) ->
+    {wrq:path(ReqState#wm_reqstate.reqdata), ReqState};
+call({get_req_header, K}, {?MODULE, ReqState}) ->
     {wrq:get_req_header(K, ReqState#wm_reqstate.reqdata), ReqState};
-call({set_response_code, Code}) ->
+call({set_response_code, Code}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:set_response_code(
                                      Code, ReqState#wm_reqstate.reqdata)}};
-call({set_resp_header, K, V}) ->
+call({set_resp_header, K, V}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:set_resp_header(
                                      K, V, ReqState#wm_reqstate.reqdata)}};
-call({set_resp_headers, Hdrs}) ->
+call({set_resp_headers, Hdrs}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:set_resp_headers(
                                      Hdrs, ReqState#wm_reqstate.reqdata)}};
-call({remove_resp_header, K}) ->
+call({remove_resp_header, K}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:remove_resp_header(
                                      K, ReqState#wm_reqstate.reqdata)}};
-call({merge_resp_headers, Hdrs}) ->
+call({merge_resp_headers, Hdrs}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:merge_resp_headers(
                                      Hdrs, ReqState#wm_reqstate.reqdata)}};
-call({append_to_response_body, Data}) ->
+call({append_to_response_body, Data}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:append_to_response_body(
                                      Data, ReqState#wm_reqstate.reqdata)}};
-call({set_disp_path, P}) ->
+call({set_disp_path, P}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:set_disp_path(
                                      P, ReqState#wm_reqstate.reqdata)}};
-call(do_redirect) ->
+call(do_redirect, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{
            reqdata=wrq:do_redirect(true, ReqState#wm_reqstate.reqdata)}};
-call({send_response, Code}) ->
-    {Reply, NewState} = 
+call({send_response, Code}, Req) ->
+    {Reply, NewState} =
         case Code of
             200 ->
-                send_ok_response();
+                send_ok_response(Req);
             _ ->
-                send_response(Code)
+                send_response(Code, Req)
         end,
     LogData = NewState#wm_reqstate.log_data,
     NewLogData = LogData#wm_log_data{finish_time=now()},
     {Reply, NewState#wm_reqstate{log_data=NewLogData}};
-call(resp_body) -> {wrq:resp_body(ReqState#wm_reqstate.reqdata), ReqState};
-call({set_resp_body, Body}) ->
+call(resp_body, {?MODULE, ReqState}) ->
+    {wrq:resp_body(ReqState#wm_reqstate.reqdata), ReqState};
+call({set_resp_body, Body}, {?MODULE, ReqState}) ->
     {ok, ReqState#wm_reqstate{reqdata=wrq:set_resp_body(Body,
                                        ReqState#wm_reqstate.reqdata)}};
-call(has_resp_body) ->
+call(has_resp_body, {?MODULE, ReqState}) ->
     Reply = case wrq:resp_body(ReqState#wm_reqstate.reqdata) of
                 undefined -> false;
                 <<>> -> false;
                 _ -> true
             end,
     {Reply, ReqState};
-call({get_metadata, Key}) ->
+call({get_metadata, Key}, {?MODULE, ReqState}) ->
     Reply = case dict:find(Key, ReqState#wm_reqstate.metadata) of
                 {ok, Value} -> Value;
                 error -> undefined
             end,
     {Reply, ReqState};
-call({set_metadata, Key, Value}) ->
+call({set_metadata, Key, Value}, {?MODULE, ReqState}) ->
     NewDict = dict:store(Key, Value, ReqState#wm_reqstate.metadata),
     {ok, ReqState#wm_reqstate{metadata=NewDict}};
-call(path_tokens) -> {wrq:path_tokens(ReqState#wm_reqstate.reqdata), ReqState};
-call(req_cookie) -> {wrq:req_cookie(ReqState#wm_reqstate.reqdata), ReqState};
-call(req_qs) -> {wrq:req_qs(ReqState#wm_reqstate.reqdata), ReqState};
+call(path_tokens, {?MODULE, ReqState}) ->
+    {wrq:path_tokens(ReqState#wm_reqstate.reqdata), ReqState};
+call(req_cookie, {?MODULE, ReqState}) ->
+    {wrq:req_cookie(ReqState#wm_reqstate.reqdata), ReqState};
+call(req_qs, {?MODULE, ReqState}) ->
+    {wrq:req_qs(ReqState#wm_reqstate.reqdata), ReqState};
 call({load_dispatch_data, PathProps, HostTokens, Port,
-      PathTokens, AppRoot, DispPath}) ->
+      PathTokens, AppRoot, DispPath}, {?MODULE, ReqState}) ->
     PathInfo = dict:from_list(PathProps),
     NewState = ReqState#wm_reqstate{reqdata=wrq:load_dispatch_data(
                         PathInfo,HostTokens,Port,PathTokens,AppRoot,
                         DispPath,ReqState#wm_reqstate.reqdata)},
     {ok, NewState};
-call(log_data) -> {ReqState#wm_reqstate.log_data, ReqState};
-call(notes) -> {wrq:get_notes(ReqState#wm_reqstate.reqdata), ReqState}.
+call(log_data, {?MODULE, ReqState}) -> {ReqState#wm_reqstate.log_data, ReqState};
+call(notes, {?MODULE, ReqState}) -> {wrq:get_notes(ReqState#wm_reqstate.reqdata), ReqState};
+call(Arg, #wm_reqstate{}=ReqState) -> call(Arg, {?MODULE, ReqState}).
 
-get_header_value(K) ->
-    {wrq:get_req_header(K, ReqState#wm_reqstate.reqdata), ReqState}.
+get_header_value(K, {?MODULE, ReqState}) ->
+    {wrq:get_req_header(K, ReqState#wm_reqstate.reqdata), ReqState};
+get_header_value(K, ReqState) ->
+    get_header_value(K, {?MODULE, ReqState}).
 
-get_outheader_value(K) ->
+get_outheader_value(K, {?MODULE, ReqState}) ->
     {mochiweb_headers:get_value(K,
-      wrq:resp_headers(ReqState#wm_reqstate.reqdata)), ReqState}.
+                                wrq:resp_headers(ReqState#wm_reqstate.reqdata)), ReqState};
+get_outheader_value(K, ReqState) ->
+    get_outheader_value(K, {?MODULE, ReqState}).
 
 send(Socket, Data) ->
     case mochiweb_socket:send(Socket, iolist_to_binary(Data)) of
@@ -298,31 +344,33 @@ send_chunk(Socket, Data) ->
     send(Socket, <<"\r\n">>),
     Size.
 
-send_ok_response() ->
+send_ok_response({?MODULE, ReqState}=Req) ->
     RD0 = ReqState#wm_reqstate.reqdata,
-    {Range, State} = get_range(),
+    {Range, State} = get_range(Req),
     case Range of
         X when X =:= undefined; X =:= fail ->
-            send_response(200);
+            send_response(200, Req);
         Ranges ->
             {PartList, Size} = range_parts(RD0, Ranges),
             case PartList of
                 [] -> %% no valid ranges
                     %% could be 416, for now we'll just return 200
-                    send_response(200);
+                    send_response(200, Req);
                 PartList ->
-                    {RangeHeaders, RangeBody} = parts_to_body(PartList, Size),
+                    {RangeHeaders, RangeBody} =
+                        parts_to_body(PartList, Size, Req),
                     RespHdrsRD = wrq:set_resp_headers(
                              [{"Accept-Ranges", "bytes"} | RangeHeaders], RD0),
                     RespBodyRD = wrq:set_resp_body(
                                    RangeBody, RespHdrsRD),
                     NewState = State#wm_reqstate{reqdata=RespBodyRD},
-                    send_response(206, NewState)
+                    send_response(206, NewState, Req)
             end
     end.
 
-send_response(Code) -> send_response(Code,ReqState).
-send_response(Code, PassedState=#wm_reqstate{reqdata=RD}) ->
+send_response(Code, #wm_reqstate{}=ReqState) -> send_response(Code,ReqState,{?MODULE,ReqState});
+send_response(Code, {?MODULE, ReqState}=Req) -> send_response(Code,ReqState,Req).
+send_response(Code, PassedState=#wm_reqstate{reqdata=RD}, _Req) ->
     Body0 = wrq:resp_body(RD),
     {Body,Length} = case Body0 of
         {stream, StreamBody} -> {{stream, StreamBody}, chunked};
@@ -332,11 +380,11 @@ send_response(Code, PassedState=#wm_reqstate{reqdata=RD}) ->
     end,
     send(PassedState#wm_reqstate.socket,
          [make_version(wrq:version(RD)),
-          make_code(Code), <<"\r\n">> | 
+          make_code(Code), <<"\r\n">> |
          make_headers(Code, Length, RD)]),
-    FinalLength = case wrq:method(RD) of 
+    FinalLength = case wrq:method(RD) of
          'HEAD' -> Length;
-         _ -> 
+         _ ->
             case Body of
                 {stream, Body2} ->
                     send_stream_body(PassedState#wm_reqstate.socket, Body2);
@@ -354,10 +402,10 @@ send_response(Code, PassedState=#wm_reqstate{reqdata=RD}) ->
                      log_data=FinalLogData}}.
 
 %% @doc  Infer body length from transfer-encoding and content-length headers.
-body_length() ->
-    case get_header_value("transfer-encoding") of
+body_length(Req) ->
+    case get_header_value("transfer-encoding", Req) of
         {undefined, _} ->
-            case get_header_value("content-length") of
+            case get_header_value("content-length", Req) of
                 {undefined, _} -> undefined;
                 {Length, _} -> list_to_integer(Length)
             end;
@@ -373,11 +421,11 @@ do_recv_body(PassedState=#wm_reqstate{reqdata=RD}) ->
     read_whole_stream(recv_stream_body(PassedState, MRH), [], MRB, 0).
 
 read_whole_stream({Hunk,_}, _, MaxRecvBody, SizeAcc)
-  when SizeAcc + byte_size(Hunk) > MaxRecvBody -> 
+  when SizeAcc + byte_size(Hunk) > MaxRecvBody ->
     {error, req_body_too_large};
 read_whole_stream({Hunk,Next}, Acc0, MaxRecvBody, SizeAcc) ->
     HunkSize = byte_size(Hunk),
-    if SizeAcc + HunkSize > MaxRecvBody -> 
+    if SizeAcc + HunkSize > MaxRecvBody ->
             {error, req_body_too_large};
        true ->
             Acc = [Hunk|Acc0],
@@ -390,15 +438,15 @@ read_whole_stream({Hunk,Next}, Acc0, MaxRecvBody, SizeAcc) ->
 
 recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
     put(mochiweb_request_recv, true),
-    case get_header_value("expect") of
+    case get_header_value("expect", PassedState) of
         {"100-continue", _} ->
-            send(PassedState#wm_reqstate.socket, 
+            send(PassedState#wm_reqstate.socket,
                  [make_version(wrq:version(RD)),
                   make_code(100), <<"\r\n\r\n">>]);
         _Else ->
             ok
     end,
-    case body_length() of
+    case body_length(PassedState) of
         {unknown_transfer_encoding, X} -> exit({unknown_transfer_encoding, X});
         undefined -> {<<>>, done};
         0 -> {<<>>, done};
@@ -416,11 +464,10 @@ recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
         false ->
             {ok,Data2} = mochiweb_socket:recv(Socket,MaxHunk,?IDLE_TIMEOUT),
             {Data2,
-             fun() -> recv_unchunked_body(
-                        Socket, MaxHunk, DataLeft-MaxHunk)
+             fun() -> recv_unchunked_body(Socket, MaxHunk, DataLeft-MaxHunk)
              end}
     end.
-    
+
 recv_chunked_body(Socket, MaxHunk) ->
     case read_chunk_length(Socket, false) of
         0 -> {<<>>, done};
@@ -465,8 +512,8 @@ read_chunk_length(Socket, MaybeLastChunk) ->
             exit(normal)
     end.
 
-get_range() ->
-    case get_header_value("range") of
+get_range({?MODULE, ReqState}=Req) ->
+    case get_header_value("range", Req) of
         {undefined, _} ->
             {undefined, ReqState#wm_reqstate{range=undefined}};
         {RawRange, _} ->
@@ -554,10 +601,10 @@ parse_range_request(RawRange) when is_list(RawRange) ->
             fail
     end.
 
-parts_to_body([{Start, End, Body0}], Size) ->
+parts_to_body([{Start, End, Body0}], Size, Req) ->
     %% return body for a range reponse with a single body
-    ContentType = 
-        case get_outheader_value("content-type") of
+    ContentType =
+        case get_outheader_value("content-type", Req) of
             {undefined, _} ->
                 "text/html";
             {CT, _} ->
@@ -566,7 +613,7 @@ parts_to_body([{Start, End, Body0}], Size) ->
     HeaderList = [{"Content-Type", ContentType},
                   {"Content-Range",
                    ["bytes ",
-                    mochiweb_util:make_io(Start), "-", 
+                    mochiweb_util:make_io(Start), "-",
                     mochiweb_util:make_io(End),
                     "/", mochiweb_util:make_io(Size)]}],
     Body = if is_function(Body0) ->
@@ -575,12 +622,12 @@ parts_to_body([{Start, End, Body0}], Size) ->
                    Body0
            end,
     {HeaderList, Body};
-parts_to_body(BodyList, Size) when is_list(BodyList) ->
+parts_to_body(BodyList, Size, Req) when is_list(BodyList) ->
     %% return
     %% header Content-Type: multipart/byteranges; boundary=441934886133bdee4
     %% and multipart body
-    ContentType = 
-        case get_outheader_value("content-type") of
+    ContentType =
+        case get_outheader_value("content-type", Req) of
             {undefined, _} ->
                 "text/html";
             {CT, _} ->
@@ -602,7 +649,8 @@ parts_to_body(BodyList, Size) when is_list(BodyList) ->
 
 multipart_body([], _ContentType, Boundary, _Size) ->
     end_boundary(Boundary);
-multipart_body([{Start, End, Body} | BodyList], ContentType, Boundary, Size) ->
+multipart_body([{Start, End, Body} | BodyList],
+               ContentType, Boundary, Size) ->
     [part_preamble(Boundary, ContentType, Start, End, Size),
      Body, <<"\r\n">>
      | multipart_body(BodyList, ContentType, Boundary, Size)].
@@ -665,7 +713,7 @@ make_headers(Code, Length, RD) ->
     Hdrs0 = case Code of
         304 ->
             mochiweb_headers:make(wrq:resp_headers(RD));
-        _ -> 
+        _ ->
             case Length of
                 chunked ->
                     mochiweb_headers:enter(
@@ -693,115 +741,225 @@ make_headers(Code, Length, RD) ->
         end,
     lists:foldl(F, [<<"\r\n">>], mochiweb_headers:to_list(Hdrs)).
 
-get_reqdata() -> call(get_reqdata).
+get_reqdata(#wm_reqstate{}=ReqState) -> call(get_reqdata, {?MODULE, ReqState});
+get_reqdata(Req) -> call(get_reqdata, Req).
 
-set_reqdata(RD) -> call({set_reqdata, RD}).
+set_reqdata(RD, #wm_reqstate{}=ReqState) -> call({set_reqdata, RD}, {?MODULE, ReqState});
+set_reqdata(RD, Req) -> call({set_reqdata, RD}, Req).
 
-socket() -> call(socket).
+socket(#wm_reqstate{}=ReqState) -> call(socket, {?MODULE, ReqState});
+socket(Req) -> call(socket, Req).
 
-method() -> call(method).
+method(#wm_reqstate{}=ReqState) -> call(method, {?MODULE, ReqState});
+method(Req) -> call(method, Req).
 
-version() -> call(version).
+version(#wm_reqstate{}=ReqState) -> call(version, {?MODULE, ReqState});
+version(Req) -> call(version, Req).
 
-disp_path() -> call(disp_path).
+disp_path(#wm_reqstate{}=ReqState) -> call(disp_path, {?MODULE, ReqState});
+disp_path(Req) -> call(disp_path, Req).
 
-path() -> call(path).
+path(#wm_reqstate{}=ReqState) -> call(path, {?MODULE, ReqState});
+path(Req) -> call(path, Req).
 
-raw_path() -> call(raw_path).
+raw_path(#wm_reqstate{}=ReqState) -> call(raw_path, {?MODULE, ReqState});
+raw_path(Req) -> call(raw_path, Req).
 
-req_headers() -> call(req_headers).
-headers() -> req_headers().
+req_headers(#wm_reqstate{}=ReqState) -> call(req_headers, {?MODULE, ReqState});
+req_headers(Req) -> call(req_headers, Req).
+headers(Req) -> req_headers(Req).
 
-req_body(MaxRevBody) -> call({req_body,MaxRevBody}).
-stream_req_body(MaxHunk) -> call({stream_req_body, MaxHunk}).
+req_body(MaxRevBody, #wm_reqstate{}=ReqState) -> call({req_body,MaxRevBody}, {?MODULE, ReqState});
+req_body(MaxRevBody, Req) -> call({req_body,MaxRevBody}, Req).
+stream_req_body(MaxHunk, #wm_reqstate{}=ReqState) ->
+    call({stream_req_body, MaxHunk}, {?MODULE, ReqState});
+stream_req_body(MaxHunk, Req) -> call({stream_req_body, MaxHunk}, Req).
 
-resp_headers() -> call(resp_headers).
-out_headers() -> resp_headers().
+resp_headers(#wm_reqstate{}=ReqState) -> call(resp_headers, {?MODULE, ReqState});
+resp_headers(Req) -> call(resp_headers, Req).
+out_headers(Req) -> resp_headers(Req).
 
-get_resp_header(HeaderName) -> call({get_resp_header, HeaderName}).
-get_out_header(HeaderName) -> get_resp_header(HeaderName).
+get_resp_header(HeaderName, Req) ->
+    call({get_resp_header, HeaderName}, Req).
+get_out_header(HeaderName, #wm_reqstate{}=ReqState) ->
+    get_resp_header(HeaderName, {?MODULE, ReqState});
+get_out_header(HeaderName, Req) -> get_resp_header(HeaderName, Req).
 
-has_resp_header(HeaderName) ->
-    case get_out_header(HeaderName) of
+has_resp_header(HeaderName, Req) ->
+    case get_out_header(HeaderName, Req) of
         {undefined, _} -> false;
         {_, _}         -> true
     end.
-has_out_header(HeaderName) -> has_resp_header(HeaderName).
+has_out_header(HeaderName, #wm_reqstate{}=ReqState) ->
+    has_resp_header(HeaderName, {?MODULE, ReqState});
+has_out_header(HeaderName, Req) -> has_resp_header(HeaderName, Req).
 
-has_resp_body() -> call(has_resp_body).
-has_response_body() -> has_resp_body().
+has_resp_body(#wm_reqstate{}=ReqState) -> call(has_resp_body, {?MODULE, ReqState});
+has_resp_body(Req) -> call(has_resp_body, Req).
+has_response_body(Req) -> has_resp_body(Req).
 
-response_code() -> call(response_code).
-set_response_code(Code) -> call({set_response_code, Code}).
+response_code(#wm_reqstate{}=ReqState) -> call(response_code, {?MODULE, ReqState});
+response_code(Req) -> call(response_code, Req).
+set_response_code(Code, {?MODULE, ReqState}=Req) ->
+    call({ReqState, set_response_code, Code}, Req);
+set_response_code(Code, ReqState) ->
+    set_response_code(Code, {?MODULE, ReqState}).
 
-peer() -> call(peer).
+peer(#wm_reqstate{}=ReqState) -> call(peer, {?MODULE, ReqState});
+peer(Req) -> call(peer, Req).
 
-range() -> call(range).
+range(#wm_reqstate{}=ReqState) -> call(range, {?MODULE, ReqState});
+range(Req) -> call(range, Req).
 
-req_cookie() -> call(req_cookie).
-parse_cookie() -> req_cookie().
-get_cookie_value(Key) ->
-    {ReqCookie, NewReqState} = req_cookie(),
+req_cookie(#wm_reqstate{}=ReqState) -> call(req_cookie, {?MODULE, ReqState});
+req_cookie(Req) -> call(req_cookie, Req).
+parse_cookie(Req) -> req_cookie(Req).
+get_cookie_value(Key, #wm_reqstate{}=ReqState) -> get_cookie_value(Key, {?MODULE, ReqState});
+get_cookie_value(Key, Req) ->
+    {ReqCookie, NewReqState} = req_cookie(Req),
     case lists:keyfind(Key, 1, ReqCookie) of
         false -> {undefined, NewReqState};
         {Key, Value} -> {Value, NewReqState}
     end.
 
-req_qs() -> call(req_qs).
-parse_qs() -> req_qs().
-get_qs_value(Key) ->
-    {ReqQS, NewReqState} = req_qs(),
+req_qs(#wm_reqstate{}=ReqState) -> call(req_qs, {?MODULE, ReqState});
+req_qs(Req) -> call(req_qs, Req).
+parse_qs(Req) -> req_qs(Req).
+get_qs_value(Key, #wm_reqstate{}=ReqState) -> get_qs_value(Key, {?MODULE, ReqState});
+get_qs_value(Key, Req) ->
+    {ReqQS, NewReqState} = req_qs(Req),
     case lists:keyfind(Key, 1, ReqQS) of
         false -> {undefined, NewReqState};
         {Key, Value} -> {Value, NewReqState}
     end.
-get_qs_value(Key, Default) ->
-    {ReqQS, NewReqState} = req_qs(),
+get_qs_value(Key, Default, #wm_reqstate{}=ReqState) ->
+    get_qs_value(Key, Default, {?MODULE, ReqState});
+get_qs_value(Key, Default, Req) ->
+    {ReqQS, NewReqState} = req_qs(Req),
     case lists:keyfind(Key, 1, ReqQS) of
         false -> {Default, NewReqState};
         {Key, Value} -> {Value, NewReqState}
     end.
-set_resp_body(Body) -> call({set_resp_body, Body}).
-resp_body() -> call(resp_body).
-response_body() -> resp_body().
+set_resp_body(Body, #wm_reqstate{}=ReqState) -> call({set_resp_body, Body}, {?MODULE, ReqState});
+set_resp_body(Body, Req) -> call({set_resp_body, Body}, Req).
+resp_body(#wm_reqstate{}=ReqState) -> call(resp_body, {?MODULE, ReqState});
+resp_body(Req) -> call(resp_body, Req).
+response_body(Req) -> resp_body(Req).
 
-get_req_header(K) -> call({get_req_header, K}).
+get_req_header(K, #wm_reqstate{}=ReqState) -> call({get_req_header, K}, {?MODULE, ReqState});
+get_req_header(K, Req) -> call({get_req_header, K}, Req).
 
-set_resp_header(K, V) -> call({set_resp_header, K, V}).
-add_response_header(K, V) -> set_resp_header(K, V).
+set_resp_header(K, V, Req) -> call({set_resp_header, K, V}, Req).
+add_response_header(K, V, #wm_reqstate{}=ReqState) -> set_resp_header(K, V, {?MODULE, ReqState});
+add_response_header(K, V, Req) -> set_resp_header(K, V, Req).
 
-set_resp_headers(Hdrs) -> call({set_resp_headers, Hdrs}).
-add_response_headers(Hdrs) -> set_resp_headers(Hdrs).
+set_resp_headers(Hdrs, Req) -> call({set_resp_headers, Hdrs}, Req).
+add_response_headers(Hdrs, #wm_reqstate{}=ReqState) -> set_resp_headers(Hdrs, {?MODULE, ReqState});
+add_response_headers(Hdrs, Req) -> set_resp_headers(Hdrs, Req).
 
-remove_resp_header(K) -> call({remove_resp_header, K}).
-remove_response_header(K) -> remove_resp_header(K).
+remove_resp_header(K, Req) -> call({remove_resp_header, K}, Req).
+remove_response_header(K, #wm_reqstate{}=ReqState) -> remove_resp_header(K, {?MODULE, ReqState});
+remove_response_header(K, Req) -> remove_resp_header(K, Req).
 
-merge_resp_headers(Hdrs) -> call({merge_resp_headers, Hdrs}).
-merge_response_headers(Hdrs) -> merge_resp_headers(Hdrs).
+merge_resp_headers(Hdrs, Req) -> call({merge_resp_headers, Hdrs}, Req).
+merge_response_headers(Hdrs, #wm_reqstate{}=ReqState) ->
+    merge_resp_headers(Hdrs, {?MODULE, ReqState});
+merge_response_headers(Hdrs, Req) -> merge_resp_headers(Hdrs, Req).
 
-append_to_response_body(Data) -> call({append_to_response_body, Data}).
+append_to_response_body(Data, #wm_reqstate{}=ReqState) ->
+    call({append_to_response_body, Data}, {?MODULE, ReqState});
+append_to_response_body(Data, Req) ->
+    call({append_to_response_body, Data}, Req).
 
-do_redirect() -> call(do_redirect).
+do_redirect(#wm_reqstate{}=ReqState) -> call(do_redirect, {?MODULE, ReqState});
+do_redirect(Req) -> call(do_redirect, Req).
 
-resp_redirect() -> call(resp_redirect).
+resp_redirect(#wm_reqstate{}=ReqState) -> call(resp_redirect, {?MODULE, ReqState});
+resp_redirect(Req) -> call(resp_redirect, Req).
 
-get_metadata(Key) -> call({get_metadata, Key}).
+get_metadata(Key, #wm_reqstate{}=ReqState) -> call({get_metadata, Key}, {?MODULE, ReqState});
+get_metadata(Key, Req) -> call({get_metadata, Key}, Req).
 
-set_metadata(Key, Value) -> call({set_metadata, Key, Value}).
+set_metadata(Key, Value, #wm_reqstate{}=ReqState) ->
+    call({set_metadata, Key, Value}, {?MODULE, ReqState});
+set_metadata(Key, Value, Req) -> call({set_metadata, Key, Value}, Req).
 
-get_path_info() -> call(get_path_info).
+get_path_info(#wm_reqstate{}=ReqState) -> call(get_path_info, {?MODULE, ReqState});
+get_path_info(Req) -> call(get_path_info, Req).
 
-get_path_info(Key) -> call({get_path_info, Key}).
+get_path_info(Key, #wm_reqstate{}=ReqState) -> call({get_path_info, Key}, {?MODULE, ReqState});
+get_path_info(Key, Req) -> call({get_path_info, Key}, Req).
 
-path_tokens() -> call(path_tokens).
-get_path_tokens() -> path_tokens().
+path_tokens(#wm_reqstate{}=ReqState) -> call(path_tokens, {?MODULE, ReqState});
+path_tokens(Req) -> call(path_tokens, Req).
+get_path_tokens(Req) -> path_tokens(Req).
 
-app_root() -> call(app_root).
-get_app_root() -> app_root().
+app_root(#wm_reqstate{}=ReqState) -> call(app_root, {?MODULE, ReqState});
+app_root(Req) -> call(app_root, Req).
+get_app_root(Req) -> app_root(Req).
 
 load_dispatch_data(Bindings, HostTokens, Port, PathTokens,
-                   AppRoot, DispPath) ->
+                   AppRoot, DispPath, #wm_reqstate{}=ReqState) ->
     call({load_dispatch_data, Bindings, HostTokens, Port,
-          PathTokens, AppRoot, DispPath}).
+          PathTokens, AppRoot, DispPath}, {?MODULE, ReqState});
+load_dispatch_data(Bindings, HostTokens, Port, PathTokens,
+                   AppRoot, DispPath, Req) ->
+    call({load_dispatch_data, Bindings, HostTokens, Port,
+          PathTokens, AppRoot, DispPath}, Req).
 
-log_data() -> call(log_data).
+log_data(#wm_reqstate{}=ReqState) -> call(log_data, {?MODULE, ReqState});
+log_data(Req) -> call(log_data, Req).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+reqdata_test() ->
+    ReqData = #wm_reqdata{req_headers = mochiweb_headers:make([])},
+    {ok, ReqState} = set_reqdata(ReqData, #wm_reqstate{}),
+    ?assertEqual(ReqData, element(1, get_reqdata(ReqState))).
+
+header_test() ->
+    HdrName = "Accept",
+    HdrValue = "application/json",
+    ReqData = #wm_reqdata{req_headers = mochiweb_headers:make([{HdrName, HdrValue}])},
+    {ok, ReqState} = set_reqdata(ReqData, #wm_reqstate{}),
+    ?assertEqual({HdrValue, ReqState}, get_header_value(HdrName, ReqState)),
+    ?assertEqual({HdrValue, ReqState}, get_req_header(HdrName, ReqState)).
+
+metadata_test() ->
+    Key = "webmachine",
+    Value = "eunit",
+    {ok, ReqState} = set_metadata(Key, Value, #wm_reqstate{metadata=dict:new()}),
+    ?assertEqual({Value, ReqState}, get_metadata(Key, ReqState)).
+
+peer_test() ->
+    Self = self(),
+    Pid = spawn_link(fun() ->
+                             {ok, LS} = gen_tcp:listen(0, [binary, {active, false}]),
+                             {ok, {_, Port}} = inet:sockname(LS),
+                             Self ! {port, Port},
+                             {ok, S} = gen_tcp:accept(LS),
+                             receive
+                                 stop ->
+                                     ok
+                             after 2000 ->
+                                     ok
+                             end,
+                             gen_tcp:close(S),
+                             gen_tcp:close(LS)
+                     end),
+    receive
+        {port, Port} ->
+            {ok, S} = gen_tcp:connect({127,0,0,1}, Port, [binary, {active, false}]),
+            ReqData = #wm_reqdata{req_headers = mochiweb_headers:make([])},
+            ReqState = #wm_reqstate{socket=S, reqdata=ReqData},
+            ?assertEqual({S, ReqState}, socket(ReqState)),
+            {"127.0.0.1", NReqState} = get_peer(ReqState),
+            ?assertEqual("127.0.0.1", NReqState#wm_reqstate.peer),
+            Pid ! stop,
+            gen_tcp:close(S)
+    after 2000 ->
+            exit({error, listener_fail})
+    end.
+
+-endif.

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -1,6 +1,6 @@
 %% @author Justin Sheehy <justin@basho.com>
 %% @author Andy Gross <andy@basho.com>
-%% @copyright 2007-2009 Basho Technologies
+%% @copyright 2007-2012 Basho Technologies
 %%
 %%    Licensed under the Apache License, Version 2.0 (the "License");
 %%    you may not use this file except in compliance with the License.
@@ -14,14 +14,18 @@
 %%    See the License for the specific language governing permissions and
 %%    limitations under the License.
 
--module(webmachine_resource, [R_Mod, R_ModState, R_ModExports, R_Trace]).
+-module(webmachine_resource).
 -author('Justin Sheehy <justin@basho.com>').
 -author('Andy Gross <andy@basho.com>').
--export([wrap/2]).
--export([do/2,log_d/1,stop/0]).
+-export([new/4, wrap/2, wrap/3]).
+-export([do/3,log_d/2,stop/1]).
 
+-include("wm_resource.hrl").
 -include("wm_reqdata.hrl").
 -include("wm_reqstate.hrl").
+
+new(R_Mod, R_ModState, R_ModExports, R_Trace) ->
+    {?MODULE, R_Mod, R_ModState, R_ModExports, R_Trace}.
 
 default(ping) ->
     no_default;
@@ -104,11 +108,13 @@ default(validate_content_checksum) ->
     not_validated;
 default(_) ->
     no_default.
-          
+
+wrap(Mod, Args, {?MODULE, _, _, _, _}) ->
+    wrap(Mod, Args).
 wrap(Mod, Args) ->
     case Mod:init(Args) of
         {ok, ModState} ->
-            {ok, webmachine_resource:new(Mod, ModState, 
+            {ok, webmachine_resource:new(Mod, ModState,
                            dict:from_list(Mod:module_info(exports)), false)};
         {{trace, Dir}, ModState} ->
             {ok, File} = open_log_file(Dir, Mod),
@@ -121,14 +127,20 @@ wrap(Mod, Args) ->
             {stop, bad_init_arg}
     end.
 
-do(Fun, ReqProps) when is_atom(Fun) andalso is_list(ReqProps) ->
+do(#wm_resource{}=Res, Fun, ReqProps) ->
+    #wm_resource{module=R_Mod, modstate=R_ModState,
+                 modexports=R_ModExports, trace=R_Trace} = Res,
+    do(Fun, ReqProps, {?MODULE, R_Mod, R_ModState, R_ModExports, R_Trace});
+do(Fun, ReqProps, {?MODULE, R_Mod, _, R_ModExports, R_Trace}=Req)
+  when is_atom(Fun) andalso is_list(ReqProps) ->
     case lists:keyfind(reqstate, 1, ReqProps) of
         false -> RState0 = undefined;
         {reqstate, RState0} -> ok
     end,
     put(tmp_reqstate, empty),
-    {Reply, ReqData, NewModState} = handle_wm_call(Fun, 
-                    (RState0#wm_reqstate.reqdata)#wm_reqdata{wm_state=RState0}),
+    {Reply, ReqData, NewModState} = handle_wm_call(Fun,
+                    (RState0#wm_reqstate.reqdata)#wm_reqdata{wm_state=RState0},
+                    Req),
     ReqState = case get(tmp_reqstate) of
                    empty -> RState0;
                    X -> X
@@ -137,14 +149,14 @@ do(Fun, ReqProps) when is_atom(Fun) andalso is_list(ReqProps) ->
      webmachine_resource:new(R_Mod, NewModState, R_ModExports, R_Trace),
      ReqState#wm_reqstate{reqdata=ReqData}}.
 
-handle_wm_call(Fun, ReqData) ->
+handle_wm_call(Fun, ReqData, {?MODULE,R_Mod,R_ModState,R_ModExports,R_Trace}=Req) ->
     case default(Fun) of
         no_default ->
-            resource_call(Fun, ReqData);
+            resource_call(Fun, ReqData, Req);
         Default ->
             case dict:is_key(Fun, R_ModExports) of
                 true ->
-                    resource_call(Fun, ReqData);
+                    resource_call(Fun, ReqData, Req);
                 false ->
                     if is_pid(R_Trace) ->
                             log_call(R_Trace,
@@ -162,7 +174,7 @@ trim_trace([{M,F,[RD = #wm_reqdata{},S]}|STRest]) ->
     [{M,F,[TrimRD,S]}|STRest];
 trim_trace(X) -> X.
 
-resource_call(F, ReqData) ->
+resource_call(F, ReqData, {?MODULE, R_Mod, R_ModState, _, R_Trace}) ->
     case R_Trace of
         false -> nop;
         _ -> log_call(R_Trace, attempt, R_Mod, F, [ReqData, R_ModState])
@@ -179,14 +191,19 @@ resource_call(F, ReqData) ->
     end,
     Result.
 
-log_d(DecisionID) ->
+log_d(#wm_resource{}=Res, DecisionID) ->
+    #wm_resource{module=R_Mod, modstate=R_ModState,
+                 modexports=R_ModExports, trace=R_Trace} = Res,
+    log_d(DecisionID, {?MODULE, R_Mod, R_ModState, R_ModExports, R_Trace});
+log_d(DecisionID, {?MODULE, _, _, _, R_Trace}) ->
     case R_Trace of
         false -> nop;
         _ -> log_decision(R_Trace, DecisionID)
     end.
 
-stop() -> close_log_file(R_Trace).
-    
+stop(#wm_resource{trace=R_Trace}) -> close_log_file(R_Trace);
+stop({?MODULE, _, _, _, R_Trace}) -> close_log_file(R_Trace).
+
 log_call(File, Type, M, F, Data) ->
     io:format(File,
               "{~p, ~p, ~p,~n ~p}.~n",


### PR DESCRIPTION
The webmachine_request module and webmachine_resource module were
parameterized modules, but the OTP team recently stated they're dropping
parameterized module syntax support while keeping the underlying "tuple
module" mechanism that allows such modules to work. Change these modules
into regular modules:
1. Keep the "tuple module" parameter so that they maintain complete
   backward compatibility; no calling code has to change.
2. Add clauses for all exported functions to allow them to be called either
   using parameterized module syntax or using normal M:F(A) syntax. For
   calling webmachine_request functions with normal syntax, this means passing
   an additional argument which is a #wm_reqstate{} record; for
   webmachine_resource, the additional argument is a #wm_resource record
   (added with this commit).

Supporting normal function invocation syntax for these modules means that
new webmachine applications need not be forced to use parameterized module
invocation syntax.

Add some new unit tests to webmachine_request, but more are needed.
