### PR TITLE
reimplement webmachine_util:media_type_to_detail/1 with mochiweb

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -198,10 +198,7 @@ prioritize_media(Type,Params,Acc) ->
     end.
 
 media_type_to_detail(MType) ->
-    [CType|Params] = string:tokens(MType, ";"),
-    MParams = [list_to_tuple([string:strip(KV) || KV <- string:tokens(X,"=")])
-                || X <- Params],
-    {CType, MParams}.                       
+    mochiweb_util:parse_header(MType).
 
 accept_header_to_media_types(HeadVal) ->
     % given the value of an accept header, produce an ordered list
@@ -377,6 +374,11 @@ choose_media_type_qval_test() ->
       || I <- HtmlMatch ],
     [ ?assertEqual("image/jpeg", choose_media_type(Provided, I))
       || I <- JpgMatch ].
+
+media_type_extra_whitespace_test() ->
+    MType = "application/x-www-form-urlencoded          ;      charset      =       utf8",
+    ?assertEqual({"application/x-www-form-urlencoded",[{"charset","utf8"}]},
+                 webmachine_util:media_type_to_detail(MType)).
 
 convert_request_date_test() ->
     ?assertMatch({{_,_,_},{_,_,_}},


### PR DESCRIPTION
Pull request #56 suggested changes to
webmachine_util:media_type_to_detail/1 to handle extra whitespace
correctly. Address this issue instead by replacing the body of
webmachine_util:media_type_to_detail/1 with a call to
mochiweb_util:parse_header/1. Also add a unit test for this whitespace
issue.
