### PR TITLE
validate project name passed to new_webmachine.sh

### DIFF
--- a/scripts/new_webmachine.sh
+++ b/scripts/new_webmachine.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 
+SCRIPT=${0##*/}
 NAME=$1
 DESTDIR=$2
 
-if [ -z $NAME ] || [[ $NAME =~ ^[\.\~\/] ]]; then
+usage() {
     echo "usage: new_webmachine.sh name [destdir]"
+}
+
+if [ -z $NAME ] || [[ $NAME =~ ^[\.\~\/] ]]; then
+    usage
+    exit 1
+fi
+
+erl -noshell -eval 'halt(if is_atom('"$NAME"') -> 0; true -> 1 end).'
+if [[ $? -ne 0 ]]; then
+    echo $SCRIPT: \""$NAME"\" is not allowed as a project name
+    echo '  The project name must begin with a lowercase letter and'
+    echo '  contain only alphanumeric characters and underscores.'
+    usage
     exit 1
 fi
 


### PR DESCRIPTION
The project name passed to new_webmachine.sh must be a legal Erlang
atom. If it's not, the resulting errors can be confusing to Erlang
newcomers. Use erl to ensure the name is an atom.

Addresses pull request #65.
