### PR TITLE
pass method,scheme,http vsn into rewrite

### DIFF
--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -37,16 +37,21 @@ stop() ->
     application:stop(webmachine).
 
 new_request(mochiweb, Request) ->
+    Method = Request:get(method),
+    Scheme = Request:get(scheme),
+    Version = Request:get(version),
     {Headers, RawPath} = case application:get_env(webmachine, rewrite_module) of
         {ok, RewriteMod} ->
-            do_rewrite(RewriteMod, Request);
+            do_rewrite(RewriteMod, 
+                       Method, 
+                       Scheme, 
+                       Version, 
+                       Request:get(headers), 
+                       Request:get(raw_path));
         undefined ->
             {Request:get(headers), Request:get(raw_path)}
     end,
     Socket = Request:get(socket),
-    Method = Request:get(method),
-    Scheme = Request:get(scheme),
-    Version = Request:get(version),
     InitState = #wm_reqstate{socket=Socket,
                           reqdata=wrq:create(Method,Scheme,Version,RawPath,Headers)},
     
@@ -64,13 +69,13 @@ new_request(mochiweb, Request) ->
                            response_length=0},
     webmachine_request:new(PeerState#wm_reqstate{log_data=LogData}).
 
-do_rewrite(RewriteMod, Request) ->
-    case RewriteMod:rewrite(Request:get(headers), Request:get(raw_path)) of
+do_rewrite(RewriteMod, Method, Scheme, Version, Headers, RawPath) ->
+    case RewriteMod:rewrite(Method, Scheme, Version, Headers, RawPath) of
         %% only raw path has been rewritten (older style rewriting)
-        RawPath when is_list(RawPath) -> 
-            {Request:get(headers), RawPath};
+        NewPath when is_list(NewPath) -> {Headers, NewPath};
+
         %% headers and raw path rewritten (new style rewriting)
-        {Headers, RawPath} -> {Headers,RawPath}
+        {NewHeaders, NewPath} -> {NewHeaders,NewPath}
     end.
 
 


### PR DESCRIPTION
changed `rewrite/2` to `rewrite/5`, taking additionally the HTTP Method, scheme and HTTP version. These values cannot be rewritten (the return value of the function has not changed) but they may be used when determining the rewritten headers and path. 
