### PR TITLE
Update demo app: rebar deps, ensure inets is running, improve README

### DIFF
--- a/demo/README
+++ b/demo/README
@@ -27,9 +27,17 @@ You probably want to do one of a couple of things at this point:
 1. Start up the skeleton application:
    $ ./start.sh
 
-2. Change the basic application:
+2. Test the basic application: 
+   Visit http://localhost:8000/demo
+
+3. Change the basic application:
    edit src/webmachine_demo_resource.erl
 
-3. Add some new resources:
+4. Test the filesystem resource:
+   $ mkdir /tmp/fs
+   $ echo "Hello World." > /tmp/fs/demo.txt
+   Visit http://localhost:8000/fs/demo.txt
+
+5. Add some new resources:
    edit src/YOUR_NEW_RESOURCE.erl
    edit priv/dispatch.conf

--- a/demo/rebar.config
+++ b/demo/rebar.config
@@ -1,3 +1,3 @@
 %%-*- mode: erlang -*-
 
-{deps, [{webmachine, "1.7.*", {git, "git://github.com/basho/webmachine", "HEAD"}}]}.
+{deps, [{webmachine, "1.9.*", {git, "git://github.com/basho/webmachine", "HEAD"}}]}.

--- a/demo/src/webmachine_demo.erl
+++ b/demo/src/webmachine_demo.erl
@@ -24,6 +24,7 @@ start_link() ->
 %% @spec start() -> ok
 %% @doc Start the webmachine_demo server.
 start() ->
+    ensure_started(inets), 
     ensure_started(crypto),
     ensure_started(mochiweb),
     application:set_env(webmachine, webmachine_logger_module, 


### PR DESCRIPTION
Updated demo app to be more intuitive for those relatively new to Erlang and Webmachine. 

Demo wouldn't compile with rebar.config webmachine dependency set to 1.7.\* - updated to 1.9.*

Fixed error due to inets not running when starting demo app.

Added a couple concrete steps to README file to test the basic app and the file resource module.
