### PR TITLE
Store the dispatch_list in ETS, not application:set_env

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -54,7 +54,7 @@ start(Options) ->
       {undefined, _} -> {?MODULE, Options5};
       {PN, O6} -> {PN, O6}
     end,
-    application_set_unless_env(webmachine, dispatch_list, DispatchList),
+    webmachine_router:init_routes(DispatchList),
     application_set_unless_env(webmachine, error_handler, ErrorHandler),
     case RewriteModule of
         undefined ->
@@ -73,7 +73,7 @@ stop() ->
 
 loop(MochiReq) ->
     Req = webmachine:new_request(mochiweb, MochiReq),
-    {ok, DispatchList} = application:get_env(webmachine, dispatch_list),
+    DispatchList = webmachine_router:get_routes(),
     Host = case host_headers(Req) of
                [H|_] -> H;
                [] -> []


### PR DESCRIPTION
Use a protected, named table, so everyone can read it, but only
webmachine_router can write to it. The owner of the table is
webmachine_router with the heir of the process being the supervisor.

If webmachine_router is restarted, the supervisor gives ownership of the
table to the newly spawned webmachine_router process again. This means
that routing configuration is not lost if webmachine_router crashes.

The overall goal of this is to allow webmachine routes to be unregistered in an application's prep_stop callback. Calls to applicationLset_env in prep_stop go into a message loop because the application process is busy calling prep_stop().

cc @jrwest 
