### PR TITLE
Wrd content length with streaming rebased 1

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -633,6 +633,8 @@ encode_body(Body) ->
     case Body of
         {stream, StreamBody} ->
             {stream, make_encoder_stream(Encoder, Charsetter, StreamBody)};
+        {known_length_stream, Size, StreamBody} ->
+            {known_length_stream, Size, make_encoder_stream(Encoder, Charsetter, StreamBody)};
         {stream, Size, Fun} ->
             {stream, Size, make_size_encoder_stream(Encoder, Charsetter, Fun)};
         {writer, BodyFun} ->

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -634,7 +634,12 @@ encode_body(Body) ->
         {stream, StreamBody} ->
             {stream, make_encoder_stream(Encoder, Charsetter, StreamBody)};
         {known_length_stream, Size, StreamBody} ->
-            {known_length_stream, Size, make_encoder_stream(Encoder, Charsetter, StreamBody)};
+            case method() of
+                'HEAD' ->
+                    {known_length_stream, Size, empty_stream()};
+                _ ->
+                    {known_length_stream, Size, make_encoder_stream(Encoder, Charsetter, StreamBody)}
+            end;
         {stream, Size, Fun} ->
             {stream, Size, make_size_encoder_stream(Encoder, Charsetter, Fun)};
         {writer, BodyFun} ->
@@ -642,6 +647,10 @@ encode_body(Body) ->
         _ ->
             Encoder(Charsetter(iolist_to_binary(Body)))
     end.
+
+%% @private
+empty_stream() ->
+    {<<>>, fun() -> {<<>>, done} end}.
 
 make_encoder_stream(Encoder, Charsetter, {Body, done}) ->
     {Encoder(Charsetter(Body)), done};

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -374,6 +374,7 @@ send_response(Code, PassedState=#wm_reqstate{reqdata=RD}, _Req) ->
     Body0 = wrq:resp_body(RD),
     {Body,Length} = case Body0 of
         {stream, StreamBody} -> {{stream, StreamBody}, chunked};
+        {known_length_stream, Size, StreamBody} -> {{stream, StreamBody}, Size};
         {stream, Size, Fun} -> {{stream, Fun(0, Size-1)}, chunked};
         {writer, WriteBody} -> {{writer, WriteBody}, chunked};
         _ -> {Body0, iolist_size([Body0])}

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -141,6 +141,7 @@ resp_headers(_RD = #wm_reqdata{resp_headers=RespH}) -> RespH. % mochiheaders
 
 resp_body(_RD = #wm_reqdata{resp_body=undefined}) -> undefined;
 resp_body(_RD = #wm_reqdata{resp_body={stream,X}}) -> {stream,X};
+resp_body(_RD = #wm_reqdata{resp_body={known_length_stream,X,Y}}) -> {known_length_stream,X,Y};
 resp_body(_RD = #wm_reqdata{resp_body={stream,X,Y}}) -> {stream,X,Y};
 resp_body(_RD = #wm_reqdata{resp_body={writer,X}}) -> {writer,X};
 resp_body(_RD = #wm_reqdata{resp_body=RespB}) when is_binary(RespB) -> RespB;


### PR DESCRIPTION
Currently streaming responses of the form `{stream, streambody()}` must be exhausted in order to determine the `Content-Length`. There are good reasons for this (the body may be processed by some content-encoding), but sometimes you want to just say, "hey webmachine, I _know_ the `Content-Length` and here it is". This is useful if you have large resources and don't want the response returned with `Transfer-Encoding: chunked`. This is also useful when you want to allow HEAD requests to return a `Content-Length` without having to exhaust a large stream. This patch adds a new stream type, `known_length_stream`, whose values look like:

``` erlang
-type known_length_stream() :: {known_length_stream, ContentLength :: non_neg_integer(), streambody()}
```

While this code has been used in Riak CS for the past year or so, I'm quite open to feedback on approaches to make this more general, etc.
