### PR TITLE
Minor Dialyzer type fixes for Riak CS

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -207,8 +207,8 @@ try_path_binding([PathSpec|Rest], PathTokens, HostRemainder, Port, HostBindings,
             PathInfo = dict:from_list(NewBindings),
             RD1 =
                 case RD of
-                    testing ->
-                        testing;
+                    testing_ignore_dialyzer_warning_here ->
+                        testing_ignore_dialyzer_warning_here;
                     _ ->
                         wrq:load_dispatch_data(PathInfo, HostRemainder, Port, Remainder,
                                                AppRoot, StringPath, RD)
@@ -359,7 +359,7 @@ bind_path_string_fail_test() ->
     ?assertEqual(fail, bind(["a","b"], ["a","c"], [], 0)).
 
 try_path_matching_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     ?assertEqual({bar, baz, [], [], ".", ""},
                  try_path_binding([{["foo"], bar, baz}], ["foo"], [], 80, [], 0, RD)),
     Dispatch = [{["a", x], foo, bar},
@@ -375,14 +375,14 @@ try_path_matching_test() ->
                  try_path_binding(Dispatch, ["b","c","z","v"], [], 80, [], 0, RD)).
 
 try_path_failing_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     ?assertEqual({no_dispatch_match, ["a"]},
                  try_path_binding([{["b"], x, y}], ["a"], [], 80, [], 0, RD)).
 
 %% host binding
 
 try_host_binding_nohosts_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     PathDispatches = [{["a"], foo, bar},
                       {["b"], baz, quux}],
     ?assertEqual(try_host_binding([{{['*'],'*'},PathDispatches}],
@@ -403,7 +403,7 @@ try_host_binding_nohosts_test() ->
                                   ["quux","baz"], 1234, ["b"], 0, RD)).
 
 try_host_binding_noport_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     Dispatch = [{["foo","bar"], [{["a"],x,y}]},
                 {["baz","quux"],[{["b"],z,q}]},
                 {[m,"quux"],    [{["c"],r,s}]},
@@ -427,7 +427,7 @@ try_host_binding_noport_test() ->
                                   ["quux","no"], 82, ["d"], 0, RD)).
 
 try_host_binding_fullmatch_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     Dispatch = [{{["foo","bar"],80},[{["a"],x,y}]},
                 {{[foo,"bar"],80},  [{["b"],z,q}]},
                 {{[foo,"bar"],baz}, [{["c"],r,s}]},
@@ -461,7 +461,7 @@ try_host_binding_wildcard_token_order_test() ->
                  dispatch("foo.bar.baz.quux.com","/",Dispatch,RD)).
 
 try_host_binding_fail_test() ->
-    RD = testing,
+    RD = testing_ignore_dialyzer_warning_here,
     ?assertEqual({no_dispatch_match, {["bar","foo"], 1234}, ["x","y","z"]},
                  try_host_binding([], ["bar","foo"], 1234, ["x","y","z"], 0, RD)).
 


### PR DESCRIPTION
This doesn't actually get rid of a warning ... though I really did try, using this spec from "typer" and then editing to add the 'test' atom as possible for the last arg:

```
%% Spec to avoid "'testing' can never match the type {'wm_reqdata'..."
-spec try_path_binding(maybe_improper_list(),[nonempty_string()],[[any(),...]],integer(),[{_,_}],0 | 1,'testing' | {'wm_reqdata',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) -> {'no_dispatch_match',[[any(),...]]} | {_,_,[[any(),...]],[{_,_}],string(),string()}.
```

... but it didn't work. So I'm changing the used-by-eunit-tests-only atom to make it clear that this is an ignorable warning.
