### PR TITLE
Refine range header treatment

### DIFF
--- a/include/wm_reqdata.hrl
+++ b/include/wm_reqdata.hrl
@@ -2,7 +2,7 @@
                      disp_path, path, raw_path, path_info, path_tokens,
                      app_root,response_code,max_recv_body, max_recv_hunk,
                      req_cookie, req_qs, req_headers, req_body,
-                     resp_redirect, resp_headers, resp_body,
+                     resp_redirect, resp_headers, resp_body, resp_range,
                      host_tokens, port, notes
                     }).
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
 
 {deps, [
         {mochiweb, "1.5.1*", {git, "git://github.com/basho/mochiweb",
-                            {tag, "1.5.1p3"}}}
+                            {branch, "1.5"}}}
         ]}.

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -627,7 +627,7 @@ parts_to_body([{Start, End, Body0}], Size, Req) ->
                     mochiweb_util:make_io(End),
                     "/", mochiweb_util:make_io(Size)]}],
     Body = if is_function(Body0) ->
-                   {stream, Body0(Start, End)};
+                   {known_length_stream, End - Start + 1, Body0(Start, End)};
               true ->
                    Body0
            end,

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -527,14 +527,14 @@ get_range({?MODULE, ReqState}=Req) ->
         {undefined, _} ->
             {undefined, ReqState#wm_reqstate{range=undefined}};
         {RawRange, _} ->
-            Range = parse_range_request(RawRange),
+            Range = mochiweb_http:parse_range_request(RawRange),
             {Range, ReqState#wm_reqstate{range=Range}}
     end.
 
 range_parts(_RD=#wm_reqdata{resp_body={file, IoDevice}}, Ranges) ->
     Size = mochiweb_io:iodevice_size(IoDevice),
     F = fun (Spec, Acc) ->
-                case range_skip_length(Spec, Size) of
+                case mochiweb_http:range_skip_length(Spec, Size) of
                     invalid_range ->
                         Acc;
                     V ->
@@ -555,7 +555,7 @@ range_parts(RD=#wm_reqdata{resp_body={stream, {Hunk,Next}}}, Ranges) ->
     range_parts(read_whole_stream({Hunk,Next}, [], MRB, 0), Ranges);
 
 range_parts(_RD=#wm_reqdata{resp_body={stream, Size, StreamFun}}, Ranges) ->
-    SkipLengths = [ range_skip_length(R, Size) || R <- Ranges],
+    SkipLengths = [ mochiweb_http:range_skip_length(R, Size) || R <- Ranges],
     {[ {Skip, Skip+Length-1, StreamFun} || {Skip, Length} <- SkipLengths ],
      Size};
 
@@ -563,7 +563,7 @@ range_parts(Body0, Ranges) when is_binary(Body0); is_list(Body0) ->
     Body = iolist_to_binary(Body0),
     Size = size(Body),
     F = fun(Spec, Acc) ->
-                case range_skip_length(Spec, Size) of
+                case mochiweb_http:range_skip_length(Spec, Size) of
                     invalid_range ->
                         Acc;
                     {Skip, Length} ->
@@ -574,42 +574,6 @@ range_parts(Body0, Ranges) when is_binary(Body0); is_list(Body0) ->
                 end
         end,
     {lists:foldr(F, [], Ranges), Size}.
-
-range_skip_length(Spec, Size) ->
-    case Spec of
-        {none, R} when R =< Size, R >= 0 ->
-            {Size - R, R};
-        {none, _OutOfRange} ->
-            {0, Size};
-        {R, none} when R >= 0, R < Size ->
-            {R, Size - R};
-        {_OutOfRange, none} ->
-            invalid_range;
-        {Start, End} when 0 =< Start, Start =< End, End < Size ->
-            {Start, End - Start + 1};
-        {_OutOfRange, _End} ->
-            invalid_range
-    end.
-
-parse_range_request(RawRange) when is_list(RawRange) ->
-    try
-        "bytes=" ++ RangeString = RawRange,
-        Ranges = string:tokens(RangeString, ","),
-        lists:map(fun ("-" ++ V)  ->
-                          {none, list_to_integer(V)};
-                      (R) ->
-                          case string:tokens(R, "-") of
-                              [S1, S2] ->
-                                  {list_to_integer(S1), list_to_integer(S2)};
-                              [S] ->
-                                  {list_to_integer(S), none}
-                          end
-                  end,
-                  Ranges)
-    catch
-        _:_ ->
-            fail
-    end.
 
 parts_to_body([{Start, End, Body0}], Size, Req) ->
     %% return body for a range reponse with a single body

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -27,6 +27,7 @@
 -export([media_type_to_detail/1,
          quoted_string/1,
          split_quoted_strings/1]).
+-export([parse_range/2]).
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -369,6 +370,21 @@ now_diff_milliseconds({M,S,U}, {M,S1,U1}) ->
     ((S-S1) * 1000) + ((U-U1) div 1000);
 now_diff_milliseconds({M,S,U}, {M1,S1,U1}) ->
     ((M-M1)*1000000+(S-S1))*1000 + ((U-U1) div 1000).
+
+-spec parse_range(RawRange::string(), ResourceLength::non_neg_integer()) ->
+                         [{Start::non_neg_integer(), End::non_neg_integer()}].
+parse_range(RawRange, ResourceLength) when is_list(RawRange) ->
+    parse_range(mochiweb_http:parse_range_request(RawRange), ResourceLength, []).
+
+parse_range([], _ResourceLength, Acc) ->
+    lists:reverse(Acc);
+parse_range([Spec | Rest], ResourceLength, Acc) ->
+    case mochiweb_http:range_skip_length(Spec, ResourceLength) of
+        invalid_range ->
+            parse_range(Rest, ResourceLength, Acc);
+        {Skip, Length} ->
+            parse_range(Rest, ResourceLength, [{Skip, Skip + Length - 1} | Acc])
+    end.
 
 %%
 %% TEST

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -26,7 +26,7 @@
          get_resp_header/2,set_resp_header/3,set_resp_headers/2,
          set_disp_path/2,set_req_body/2,set_resp_body/2,set_response_code/2,
          merge_resp_headers/2,remove_resp_header/2,
-         append_to_resp_body/2,append_to_response_body/2,
+         append_to_resp_body/2,append_to_response_body/2, set_resp_range/2,
          max_recv_body/1,set_max_recv_body/2,
          get_cookie_value/2,get_qs_value/2,get_qs_value/3,set_peer/2,
          add_note/3, get_notes/1]).
@@ -56,6 +56,7 @@ create(Method,Scheme,Version,RawPath,Headers) ->
       disp_path=defined_in_load_dispatch_data,
       resp_redirect=false, resp_headers=mochiweb_headers:empty(),
       resp_body = <<>>, response_code=500,
+      resp_range = follow_request,
       notes=[]}).
 create(RD = #wm_reqdata{raw_path=RawPath}) ->
     {Path, _, _} = mochiweb_util:urlsplit_path(RawPath),
@@ -205,6 +206,13 @@ append_to_response_body(Data, RD=#wm_reqdata{resp_body=RespB}) ->
         false -> % MUST BE an iolist! else, fail.
             append_to_response_body(iolist_to_binary(Data), RD)
     end.
+
+-spec set_resp_range(follow_request | ignore_request, #wm_reqdata{}) -> #wm_reqdata{}.
+%% follow_request : range responce for range request, normal responce for non-range one
+%% ignore_request : normal resopnse for either range reuqest or non-range one
+set_resp_range(RespRange, RD)
+  when RespRange =:= follow_request orelse RespRange =:= ignore_request ->
+    RD#wm_reqdata{resp_range = RespRange}.
 
 get_cookie_value(Key, RD) when is_list(Key) -> % string
     case lists:keyfind(Key, 1, req_cookie(RD)) of


### PR DESCRIPTION
- Add functionality to respnd with normal (non-Range) contents even if there is Range header in requests.
- Change transfer encoding of responses to not use chunked in case of single range request
