### PR TITLE
Guess text/css MIME type for .less files

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -78,7 +78,7 @@ guess_mime(File) ->
         ".js" ->
             "application/x-javascript";
         ".less" ->
-            "text/less";
+            "text/css";
         ".m4v" ->
             "video/mp4";
         ".manifest" ->

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -77,6 +77,8 @@ guess_mime(File) ->
             "image/jpeg";
         ".js" ->
             "application/x-javascript";
+        ".less" ->
+            "text/css";
         ".m4v" ->
             "video/mp4";
         ".manifest" ->

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -78,7 +78,7 @@ guess_mime(File) ->
         ".js" ->
             "application/x-javascript";
         ".less" ->
-            "text/css";
+            "text/less";
         ".m4v" ->
             "video/mp4";
         ".manifest" ->


### PR DESCRIPTION
This is needed to avoid 406 errors when loading & parsing Less file in the browser
