### PR TITLE
Fix 500 error on non-streamed GET requests that include a Range header

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -559,6 +559,9 @@ range_parts(_RD=#wm_reqdata{resp_body={stream, Size, StreamFun}}, Ranges) ->
     {[ {Skip, Skip+Length-1, StreamFun} || {Skip, Length} <- SkipLengths ],
      Size};
 
+range_parts(#wm_reqdata{resp_body=Body}, Ranges) when is_binary(Body); is_list(Body) ->
+    range_parts(Body, Ranges);
+
 range_parts(Body0, Ranges) when is_binary(Body0); is_list(Body0) ->
     Body = iolist_to_binary(Body0),
     Size = size(Body),


### PR DESCRIPTION
This problem can be provoked by using the `webmachine_demo_fs_resource` in the provided demo application. Using a `Range` header when trying to fetch a file results in a 500 error.

Without this change:

```
13:04:53:demo(klm-non-stream-range-fix *) $ curl -H 'Range: bytes=0-10' http://localhost:8000/fs/demo.txt -v
* About to connect() to localhost port 8000 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* connected
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /fs/demo.txt HTTP/1.1
> User-Agent: curl/7.28.0
> Host: localhost:8000
> Accept: */*
> Range: bytes=0-10
> 
< HTTP/1.1 500 Internal Server Error
< Server: MochiWeb/1.1 WebMachine/1.9.2 (someone had painted it blue)
< Last-Modified: Fri, 15 Feb 2013 13:31:31 GMT
< ETag: "f53126f18c2571ecec28ccf968fa9f9a7d6904d8"
< Date: Mon, 18 Feb 2013 20:04:55 GMT
< Content-Type: text/plain
< Content-Length: 21
< 
aaaaaaaaaaaaaaaaaaaa
* Connection #0 to host localhost left intact
* Closing connection #0
```

With this change:

```
13:25:00:webmachine(klm-non-stream-range-fix) $ Range: bytes=0-10' http://localhost:8000/fs/demo.txt -v
* About to connect() to localhost port 8000 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* connected
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /fs/demo.txt HTTP/1.1
> User-Agent: curl/7.28.0
> Host: localhost:8000
> Accept: */*
> Range: bytes=0-10
> 
< HTTP/1.1 206 Partial Content
< Server: MochiWeb/1.1 WebMachine/1.9.2 (someone had painted it blue)
< Last-Modified: Fri, 15 Feb 2013 13:31:31 GMT
< ETag: "f53126f18c2571ecec28ccf968fa9f9a7d6904d8"
< Date: Mon, 18 Feb 2013 20:25:06 GMT
< Content-Type: text/plain
< Content-Range: bytes 0-10/21
< Content-Length: 11
< Accept-Ranges: bytes
< 
* Connection #0 to host localhost left intact
aaaaaaaaaaa* Closing connection #0
```
