### PR TITLE
Allow multiple webmachine instance to run in the same app

### DIFF
--- a/src/webmachine_sup.erl
+++ b/src/webmachine_sup.erl
@@ -62,5 +62,4 @@ init([]) ->
                    permanent, 5000, worker, [dynamic]},
                   {webmachine_logger_watcher_sup, {webmachine_logger_watcher_sup, start_link, []},
                    permanent, 5000, supervisor, [webmachine_logger_watcher_sup]}],
-    Processes = LogHandler ++ [Router],
-    {ok, {{one_for_one, 9, 10}, Processes}}.
+    {ok, {{one_for_one, 9, 10},  LogHandler ++ [Router]}}.


### PR DESCRIPTION
Changes to allow multiple instances of webmachine to coexist within
the same erlang application. The instances can use distinct dispatch
tables and be configured to listen on different IP addresses or port
numbers. 

The current behavior is maintained as the default, but may be
overridden by setting `default_router` to `false` in the application
environment and starting named router processes from the application
supervisor prior to calling `webmachine_mochiweb:start`.

The key is to provide a distinct name for each router using `webmachine:start_link/1` and to include that name as the value for the `name` key in the `Config` passed to `webmachine_mochiweb:start/1`.
