### PR TITLE
Bugfix for multiple routers under Riak

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -104,12 +104,17 @@ handle_get_option_result(GetOptRes, _) ->
 
 get_wm_options(Options) ->
     {DispatchList, Options1} = get_option(dispatch, Options),
-    {Name, Options2} = get_option(name, Options1),
+    {Name, Options2} =
+        case get_option(name, Options1) of
+            {undefined, Opts2} ->
+                {webmachine, Opts2};
+            NRes -> NRes
+        end,
     {RName, Options3} =
         case get_option(router_name, Options2) of
             {undefined, Opts3} ->
                 {webmachine_router, Opts3};
-            Res -> Res
+            RRes -> RRes
         end,
     {WMOptions, RestOptions} = lists:foldl(fun get_wm_option/2, {[], Options3}, ?WM_OPTIONS),
     {DispatchList, Name, RName, WMOptions, RestOptions}.

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -30,11 +30,11 @@
 -define (WM_OPTION_DEFAULTS, [{error_handler, webmachine_error_handler}]).
 
 start(Options) ->
-    {DispatchList, PName, RName, WMOptions, OtherOptions} = get_wm_options(Options),
-    webmachine_router:init_routes(RName, DispatchList),
+    {DispatchList, PName, DGroup, WMOptions, OtherOptions} = get_wm_options(Options),
+    webmachine_router:init_routes(DGroup, DispatchList),
     [application_set_unless_env_or_undef(K, V) || {K, V} <- WMOptions],
     MochiName = list_to_atom(to_list(PName) ++ "_mochiweb"),
-    LoopFun = fun(X) -> loop(RName, X) end,
+    LoopFun = fun(X) -> loop(DGroup, X) end,
     mochiweb_http:start([{name, MochiName}, {loop, LoopFun} | OtherOptions]).
 
 stop() ->
@@ -110,14 +110,14 @@ get_wm_options(Options) ->
                 {webmachine, Opts2};
             NRes -> NRes
         end,
-    {RName, Options3} =
-        case get_option(router_name, Options2) of
+    {DGroup, Options3} =
+        case get_option(dispatch_group, Options2) of
             {undefined, Opts3} ->
-                {webmachine_router, Opts3};
+                {default, Opts3};
             RRes -> RRes
         end,
     {WMOptions, RestOptions} = lists:foldl(fun get_wm_option/2, {[], Options3}, ?WM_OPTIONS),
-    {DispatchList, Name, RName, WMOptions, RestOptions}.
+    {DispatchList, Name, DGroup, WMOptions, RestOptions}.
 
 get_option(Option, Options) ->
     case lists:keytake(Option, 1, Options) of

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -33,7 +33,7 @@ start(Options) ->
     {DispatchList, PName, RName, WMOptions, OtherOptions} = get_wm_options(Options),
     webmachine_router:init_routes(RName, DispatchList),
     [application_set_unless_env_or_undef(K, V) || {K, V} <- WMOptions],
-    MochiName = list_to_atom(atom_to_list(PName) ++ "_mochiweb"),
+    MochiName = list_to_atom(to_list(PName) ++ "_mochiweb"),
     LoopFun = fun(X) -> loop(RName, X) end,
     mochiweb_http:start([{name, MochiName}, {loop, LoopFun} | OtherOptions]).
 
@@ -160,3 +160,8 @@ resource_module(Mod, _, undefined) ->
     Mod;
 resource_module(Mod, ModOpts, {ok, OptionVal}) ->
     proplists:get_value(OptionVal, ModOpts, Mod).
+
+to_list(L) when is_list(L) ->
+    L;
+to_list(A) when is_atom(A) ->
+    atom_to_list(A).

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -22,8 +22,7 @@
 
 %% The `log_dir' option is deprecated, but remove it from the
 %% options list if it is present
--define(WM_OPTIONS, [default_router,
-                     error_handler,
+-define(WM_OPTIONS, [error_handler,
                      log_dir,
                      rewrite_module,
                      resource_module_option]).
@@ -31,29 +30,12 @@
 -define (WM_OPTION_DEFAULTS, [{error_handler, webmachine_error_handler}]).
 
 start(Options) ->
-    {DispatchList, PName, WMOptions, OtherOptions} = get_wm_options(Options),
-    webmachine_router:init_routes(PName, DispatchList),
+    {DispatchList, PName, RName, WMOptions, OtherOptions} = get_wm_options(Options),
+    webmachine_router:init_routes(RName, DispatchList),
     [application_set_unless_env_or_undef(K, V) || {K, V} <- WMOptions],
-    maybe_stop_default_router(),
     MochiName = list_to_atom(atom_to_list(PName) ++ "_mochiweb"),
-    LoopFun = fun(X) -> loop(PName, X) end,
+    LoopFun = fun(X) -> loop(RName, X) end,
     mochiweb_http:start([{name, MochiName}, {loop, LoopFun} | OtherOptions]).
-
-maybe_stop_default_router() ->
-    case application:get_env(webmachine, default_router) of
-        {ok, false} ->
-            delete_default_router(stop_default_router());
-        _ ->
-            ok
-    end.
-
-stop_default_router() ->
-    supervisor:terminate_child(webmachine_sup, webmachine_router).
-
-delete_default_router(ok) ->
-    supervisor:delete_child(webmachine_sup, webmachine_router);
-delete_default_router({error, _Reason}) ->
-    ok.
 
 stop() ->
     {registered_name, PName} = process_info(self(), registered_name),
@@ -122,15 +104,15 @@ handle_get_option_result(GetOptRes, _) ->
 
 get_wm_options(Options) ->
     {DispatchList, Options1} = get_option(dispatch, Options),
-    {Name, Options2} =
-        case get_option(name, Options1) of
-            {undefined, Opts2} ->
-                {webmachine_router, Opts2};
-            Res ->
-                Res
+    {Name, Options2} = get_option(name, Options1),
+    {RName, Options3} =
+        case get_option(router_name, Options2) of
+            {undefined, Opts3} ->
+                {webmachine_router, Opts3};
+            Res -> Res
         end,
-    {WMOptions, RestOptions} = lists:foldl(fun get_wm_option/2, {[], Options2}, ?WM_OPTIONS),
-    {DispatchList, Name, WMOptions, RestOptions}.
+    {WMOptions, RestOptions} = lists:foldl(fun get_wm_option/2, {[], Options3}, ?WM_OPTIONS),
+    {DispatchList, Name, RName, WMOptions, RestOptions}.
 
 get_option(Option, Options) ->
     case lists:keytake(Option, 1, Options) of

--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -69,14 +69,13 @@
 % arguments to the resource module handling the matching request.
 
 -define(SERVER, ?MODULE).
--define(DEFAULT, ?MODULE).
 
 %% @spec add_route(hostmatchterm() | pathmatchterm()) -> ok
 %% @doc Adds a route to webmachine's route table. The route should
 %%      be the format documented here:
 %% http://bitbucket.org/justin/webmachine/wiki/DispatchConfiguration
 add_route(Route) ->
-    add_route(?DEFAULT, Route).
+    add_route(default, Route).
 
 add_route(Name, Route) ->
     gen_server:call(?SERVER, {add_route, Name, Route}, infinity).
@@ -86,7 +85,7 @@ add_route(Name, Route) ->
 %%      route must be properly formatted
 %% @see add_route/2
 remove_route(Route) ->
-    remove_route(?DEFAULT, Route).
+    remove_route(default, Route).
 
 remove_route(Name, Route) ->
     gen_server:call(?SERVER, {remove_route, Name, Route}, infinity).
@@ -94,7 +93,7 @@ remove_route(Name, Route) ->
 %% @spec remove_resource(atom()) -> ok
 %% @doc Removes all routes for a specific resource module.
 remove_resource(Resource) when is_atom(Resource) ->
-    remove_resource(?DEFAULT, Resource).
+    remove_resource(default, Resource).
 
 remove_resource(Name, Resource) when is_atom(Resource) ->
     gen_server:call(?SERVER, {remove_resource, Name, Resource}, infinity).
@@ -103,7 +102,7 @@ remove_resource(Name, Resource) when is_atom(Resource) ->
 %% @doc Retrieve a list of routes and resources set in webmachine's
 %%      route table.
 get_routes() ->
-    get_routes(?DEFAULT).
+    get_routes(default).
 
 get_routes(Name) ->
     get_dispatch_list(Name).
@@ -111,7 +110,7 @@ get_routes(Name) ->
 %% @spec init_routes() -> ok
 %% @doc Set the default routes, unless the routing table isn't empty.
 init_routes(DefaultRoutes) ->
-    init_routes(?DEFAULT, DefaultRoutes).
+    init_routes(default, DefaultRoutes).
 
 init_routes(Name, DefaultRoutes) ->
     gen_server:call(?SERVER, {init_routes, Name, DefaultRoutes}, infinity).


### PR DESCRIPTION
The previous addition of multiple routers -- for the benefit of launching multiple applications -- assumed that any process calling `webmachine_mochiweb:start/1` would give its name as the name of a router process. However, in `riak_core`, the name given is:
1. A string, which is not a valid registered name.
2. Related to the interface/port on which the mochiweb listener binds, not the dispatch list.

This PR changes the behavior of multiple dispatch lists slightly such that:
1. There is only one `webmachine_router` process, but it has multiple dispatch lists in its ETS table. Since the table is public, we don't need to run multiple routers, just have a way to access the dispatch lists by name.
2. The desired dispatch list name is given as the `router_name` option, defaulting to `webmachine_router`. The `name` option given to `webmachine_mochiweb:start/1` is used ONLY as part of the listener process name, defaulting to `webmachine`.
