### PR TITLE
fix template rebar.config to specify correct webmachine version

### DIFF
--- a/priv/templates/rebar.config
+++ b/priv/templates/rebar.config
@@ -1,3 +1,3 @@
 %%-*- mode: erlang -*-
 
-{deps, [{webmachine, "1.9.*", {git, "git://github.com/basho/webmachine", "HEAD"}}]}.
+{deps, [{webmachine, "1.10.*", {git, "git://github.com/basho/webmachine", "HEAD"}}]}.


### PR DESCRIPTION
Fixes this issue when attempting to follow the Quick Start guide: https://github.com/basho/webmachine/issues/135
