### PR TITLE
Run content_types_provided handlers for POST

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -518,6 +518,7 @@ decision(v3o18) ->
     BuildBody = case method() of
         'GET' -> true;
         'HEAD' -> true;
+        'POST' -> true;
         _ -> false
     end,
     FinalBody = case BuildBody of


### PR DESCRIPTION
Run handlers returned by contect_types_provided/2 for POST requests as well. Before this change those handlers (if there're any) were run only for GET and HEAD requests.

This change is related to the issue #122.
