### PR TITLE
allow apps to supply custom reason phrases for HTTP response codes

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -59,7 +59,9 @@ d(DecisionID) ->
     log_decision(DecisionID),
     decision(DecisionID).
     
-respond(Code) ->
+respond(Code) when is_integer(Code) ->
+    respond({Code, undefined});
+respond({Code, _ReasonPhrase}=CodeAndReason) ->
     Resource = get(resource),
     EndTime = now(),
     case Code of
@@ -86,9 +88,9 @@ respond(Code) ->
         _ -> ignore
     end,
     put(code, Code),
-    wrcall({set_response_code, Code}),
+    wrcall({set_response_code, CodeAndReason}),
     resource_call(finish_request),
-    wrcall({send_response, Code}),
+    wrcall({send_response, CodeAndReason}),
     RMod = wrcall({get_metadata, 'resource_module'}),
     Notes = wrcall(notes),
     LogData0 = wrcall(log_data),

--- a/src/webmachine_logger.erl
+++ b/src/webmachine_logger.erl
@@ -107,7 +107,14 @@ format_req(#wm_log_data{method=Method,
                         response_length=ResponseLength}) ->
     User = "-",
     Time = fmtnow(),
-    Status = integer_to_list(ResponseCode),
+    Status = case ResponseCode of
+                 {Code, _ReasonPhrase} when is_integer(Code)  ->
+                     integer_to_list(Code);
+                 _ when is_integer(ResponseCode) ->
+                     integer_to_list(ResponseCode);
+                 _ ->
+                     ResponseCode
+             end,
     Length = integer_to_list(ResponseLength),
     Referer = 
         case mochiweb_headers:get_value("Referer", Headers) of

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -205,13 +205,15 @@ call({set_disp_path, P}) ->
 call(do_redirect) ->
     {ok, ReqState#wm_reqstate{
            reqdata=wrq:do_redirect(true, ReqState#wm_reqstate.reqdata)}};
-call({send_response, Code}) ->
-    {Reply, NewState} = 
+call({send_response, Code}) when is_integer(Code) ->
+    call({send_response, {Code, undefined}});
+call({send_response, {Code, ReasonPhrase}=CodeAndReason}) when is_integer(Code) ->
+    {Reply, NewState} =
         case Code of
             200 ->
-                send_ok_response();
+                send_ok_response(ReasonPhrase);
             _ ->
-                send_response(Code)
+                send_response(CodeAndReason)
         end,
     LogData = NewState#wm_reqstate.log_data,
     NewLogData = LogData#wm_log_data{finish_time=now()},
@@ -298,18 +300,18 @@ send_chunk(Socket, Data) ->
     send(Socket, <<"\r\n">>),
     Size.
 
-send_ok_response() ->
+send_ok_response(ReasonPhrase) ->
     RD0 = ReqState#wm_reqstate.reqdata,
     {Range, State} = get_range(),
     case Range of
         X when X =:= undefined; X =:= fail ->
-            send_response(200);
+            send_response({200, ReasonPhrase});
         Ranges ->
             {PartList, Size} = range_parts(RD0, Ranges),
             case PartList of
                 [] -> %% no valid ranges
                     %% could be 416, for now we'll just return 200
-                    send_response(200);
+                    send_response({200, ReasonPhrase});
                 PartList ->
                     {RangeHeaders, RangeBody} = parts_to_body(PartList, Size),
                     RespHdrsRD = wrq:set_resp_headers(
@@ -317,7 +319,7 @@ send_ok_response() ->
                     RespBodyRD = wrq:set_resp_body(
                                    RangeBody, RespHdrsRD),
                     NewState = State#wm_reqstate{reqdata=RespBodyRD},
-                    send_response(206, NewState)
+                    send_response({206, ReasonPhrase}, NewState)
             end
     end.
 
@@ -651,8 +653,12 @@ stream_multipart_part_helper(Fun, Rest, CType, Boundary, Size) ->
             end
     end.
 
-make_code(X) when is_integer(X) ->
-    [integer_to_list(X), [" " | httpd_util:reason_phrase(X)]];
+make_code({Code, undefined}) when is_integer(Code) ->
+    make_code({Code, httpd_util:reason_phrase(Code)});
+make_code({Code, ReasonPhrase}) when is_integer(Code) ->
+    [integer_to_list(Code), [" " | ReasonPhrase]];
+make_code(Code) when is_integer(Code) ->
+    make_code({Code, httpd_util:reason_phrase(Code)});
 make_code(Io) when is_list(Io); is_binary(Io) ->
     Io.
 
@@ -661,11 +667,13 @@ make_version({1, 0}) ->
 make_version(_) ->
     <<"HTTP/1.1 ">>.
 
-make_headers(Code, Length, RD) ->
+make_headers({Code, _ReasonPhrase}, Length, RD) ->
+    make_headers(Code, Length, RD);
+make_headers(Code, Length, RD) when is_integer(Code) ->
     Hdrs0 = case Code of
         304 ->
             mochiweb_headers:make(wrq:resp_headers(RD));
-        _ -> 
+        _ ->
             case Length of
                 chunked ->
                     mochiweb_headers:enter(

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -170,6 +170,8 @@ set_req_body(Body, RD) -> RD#wm_reqdata{req_body=Body}.
 
 set_resp_body(Body, RD) -> RD#wm_reqdata{resp_body=Body}.
 
+set_response_code({Code, _ReasonPhrase}=CodeAndReason, RD) when is_integer(Code) ->
+    RD#wm_reqdata{response_code=CodeAndReason};
 set_response_code(Code, RD) when is_integer(Code) ->
     RD#wm_reqdata{response_code=Code}.
 

--- a/www/resources.html
+++ b/www/resources.html
@@ -59,6 +59,7 @@ Each function is described below, showing the default and allowed values that ma
 <table><tr><th>Result</th><th>Effect</th></tr>
 <tr><td class="fwf lhcol">{error, Err::term()}</td><td>Immediately end processing of this request, returning a 500 response code.  The response body will contain the <span class="fwf"> Err </span> term.</td></tr>
 <tr><td class="fwf lhcol">{halt, Code::integer()}</td><td>Immediately end processing of this request, returning response code Code.  It is the responsibility of the resource to ensure that all necessary response header and body elements are filled in <span class="fwf"> ReqData </span> in order to make that reponse code valid.</td></tr>
+<tr><td class="fwf lhcol">{halt, {Code::integer(), ReasonPhrase::iolist()}}</td><td>Same as <span class="fwf"> {halt, Code::integer()} </span> but supply a custom reason phrase for the HTTP status code as well.</td></tr>
 </table>
 
 <p>


### PR DESCRIPTION
Allow applications to return:

{halt, {Code::integer(), ReasonPhrase::iolist()}}

in order to provide custom reason phrases in their responses. The original
{halt, Code} also still works.
