### PR TITLE
Custom reason phrase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ deps/*
 *.beam
 .eunit/*
 ebin/*.app
+doc/*

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -59,7 +59,9 @@ d(DecisionID) ->
     log_decision(DecisionID),
     decision(DecisionID).
 
-respond(Code) ->
+respond(Code) when is_integer(Code) ->
+    respond({Code, undefined});
+respond({Code, _ReasonPhrase}=CodeAndReason) ->
     Resource = get(resource),
     EndTime = now(),
     case Code of
@@ -86,9 +88,9 @@ respond(Code) ->
         _ -> ignore
     end,
     put(code, Code),
-    wrcall({set_response_code, Code}),
+    wrcall({set_response_code, CodeAndReason}),
     resource_call(finish_request),
-    wrcall({send_response, Code}),
+    wrcall({send_response, CodeAndReason}),
     RMod = wrcall({get_metadata, 'resource_module'}),
     Notes = wrcall(notes),
     LogData0 = wrcall(log_data),

--- a/src/webmachine_log_handler.erl
+++ b/src/webmachine_log_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2011-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2011-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -91,7 +91,14 @@ format_req(#wm_log_data{method=Method,
                         response_length=ResponseLength}) ->
     User = "-",
     Time = webmachine_log:fmtnow(),
-    Status = integer_to_list(ResponseCode),
+    Status = case ResponseCode of
+                 {Code, _ReasonPhrase} when is_integer(Code)  ->
+                     integer_to_list(Code);
+                 _ when is_integer(ResponseCode) ->
+                     integer_to_list(ResponseCode);
+                 _ ->
+                     ResponseCode
+             end,
     Length = integer_to_list(ResponseLength),
     Referer =
         case mochiweb_headers:get_value("Referer", Headers) of

--- a/src/webmachine_perf_log_handler.erl
+++ b/src/webmachine_perf_log_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2011-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2011-2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -93,7 +93,14 @@ format_req(#wm_log_data{resource_module=Mod,
                         end_time=EndTime,
                         finish_time=FinishTime}) ->
     Time = webmachine_log:fmtnow(),
-    Status = integer_to_list(ResponseCode),
+    Status = case ResponseCode of
+                 {Code, _ReasonPhrase} when is_integer(Code)  ->
+                     integer_to_list(Code);
+                 _ when is_integer(ResponseCode) ->
+                     integer_to_list(ResponseCode);
+                 _ ->
+                     ResponseCode
+             end,
     Length = integer_to_list(ResponseLength),
     TTPD = webmachine_util:now_diff_milliseconds(EndTime, StartTime),
     TTPS = webmachine_util:now_diff_milliseconds(FinishTime, EndTime),

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -172,6 +172,8 @@ set_req_body(Body, RD) -> RD#wm_reqdata{req_body=Body}.
 
 set_resp_body(Body, RD) -> RD#wm_reqdata{resp_body=Body}.
 
+set_response_code({Code, _ReasonPhrase}=CodeAndReason, RD) when is_integer(Code) ->
+    RD#wm_reqdata{response_code=CodeAndReason};
 set_response_code(Code, RD) when is_integer(Code) ->
     RD#wm_reqdata{response_code=Code}.
 

--- a/www/resources.html
+++ b/www/resources.html
@@ -59,6 +59,7 @@ Each function is described below, showing the default and allowed values that ma
 <table><tr><th>Result</th><th>Effect</th></tr>
 <tr><td class="fwf lhcol">{error, Err::term()}</td><td>Immediately end processing of this request, returning a 500 response code.  The response body will contain the <span class="fwf"> Err </span> term.</td></tr>
 <tr><td class="fwf lhcol">{halt, Code::integer()}</td><td>Immediately end processing of this request, returning response code Code.  It is the responsibility of the resource to ensure that all necessary response header and body elements are filled in <span class="fwf"> ReqData </span> in order to make that reponse code valid.</td></tr>
+<tr><td class="fwf lhcol">{halt, {Code::integer(), ReasonPhrase::iolist()}}</td><td>Same as <span class="fwf"> {halt, Code::integer()} </span> but supply a custom reason phrase for the HTTP status code as well.</td></tr>
 </table>
 
 <p>


### PR DESCRIPTION
allow apps to supply custom reason phrases for HTTP response codes

Allow applications to return:

```
{halt, {Code::integer(), ReasonPhrase::iolist()}}
```

in order to provide custom reason phrases in their responses. The original `{halt, Code}` also still works.

Also, in a second commit, add the doc directory to .gitignore.
