### PR TITLE
webmachine_dispatcher crashes on malformed Host header

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -59,7 +59,10 @@ split_host_port(HostAsString, Scheme) ->
             {split_host(HostPart), default_port(Scheme)};
         [] ->
             %% no host header
-            {[], default_port(Scheme)}
+            {[], default_port(Scheme)};
+        _ ->
+            %% Invalid host header
+            {invalid_host, default_port(Scheme)}
     end.
 
 split_host(HostAsString) ->
@@ -150,6 +153,8 @@ default_port(https) -> 443.
 
 %% @type dispfail() = {no_dispatch_match, pathtokens()}.
 
+try_host_binding(_Dispatch, invalid_host, _Port, _Path, _Depth, _RD) ->
+    {error, invalid_host};
 try_host_binding(Dispatch, Host, Port, Path, Depth, RD) ->
     %% save work during each dispatch attempt by reversing Host up front
     try_host_binding1(Dispatch, lists:reverse(Host), Port, Path, Depth, RD).

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -368,6 +368,10 @@ unescape_quoted_string([Char | Rest], Acc) ->
 
 %% @doc  Compute the difference between two now() tuples, in milliseconds.
 %% @spec now_diff_milliseconds(now(), now()) -> integer()
+now_diff_milliseconds(undefined, undefined) ->
+    0;
+now_diff_milliseconds(undefined, T2) ->
+    now_diff_milliseconds(os:timestamp(), T2);
 now_diff_milliseconds({M,S,U}, {M,S1,U1}) ->
     ((S-S1) * 1000) + ((U-U1) div 1000);
 now_diff_milliseconds({M,S,U}, {M1,S1,U1}) ->


### PR DESCRIPTION
When a misconfigured client sends in a Host header of the form "Host: foo.bar.baz:80:80" (or really anything not of the expected form "{host}" or "{host}:{port}" webmachine handler process crashes instead of gracefully returning an error code.

CRASH REPORT Process <0.24640.19> with 0 neighbours crashed with reason: no case clause matching ["foo.bar.com","80","80"] in webmachine_dispatcher:split_host_port/1 line 55
