### PR TITLE
Call the error handler for all codes >= 400.

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -65,7 +65,7 @@ respond({Code, _ReasonPhrase}=CodeAndReason) ->
     Resource = get(resource),
     EndTime = now(),
     case Code of
-        404 ->
+        N when N >= 400 ->
             {ok, ErrorHandler} = application:get_env(webmachine, error_handler),
             Reason = {none, none, []},
             {ErrorHTML,ReqState} = ErrorHandler:render_error(


### PR DESCRIPTION
Inside respond, the current code only calls the error handler for 404 error
codes.  This means that if the resource returns {halt, 403} or similar,
then the registered error handler does not get invoked and no error body is
sent.

This change calls the error handler for all codes >= 400.  This means that
the body of the response will have an appropriate error message rather than
being blank.

In my case I am registering a custom error handler that returns JSON rather
than HTML, and it is important for that error handler to have a chance to set
a body in the response, no matter what the error code is.

This changes the default behavior in that responses for non-404 errors will
now have an error body, as set by webmachine_error_handler.  That seems to
me like the right behavior anyway.
