### PR TITLE
fix wrq:response_code/1 to handle custom reason phrase

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -693,7 +693,7 @@ stream_multipart_part_helper(Fun, Rest, CType, Boundary, Size) ->
 make_code({Code, undefined}) when is_integer(Code) ->
     make_code({Code, httpd_util:reason_phrase(Code)});
 make_code({Code, ReasonPhrase}) when is_integer(Code) ->
-    [integer_to_list(Code), [" " | ReasonPhrase]];
+    [integer_to_list(Code), [" ", ReasonPhrase]];
 make_code(Code) when is_integer(Code) ->
     make_code({Code, httpd_util:reason_phrase(Code)});
 make_code(Io) when is_list(Io); is_binary(Io) ->

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -100,6 +100,7 @@ host_tokens(_RD = #wm_reqdata{host_tokens=HostT}) -> HostT. % list of strings
 
 port(_RD = #wm_reqdata{port=Port}) -> Port. % integer
 
+response_code(_RD = #wm_reqdata{response_code={C,_ReasonPhrase}}) when is_integer(C) -> C;
 response_code(_RD = #wm_reqdata{response_code=C}) when is_integer(C) -> C.
 
 req_cookie(_RD = #wm_reqdata{req_cookie=C}) when is_list(C) -> C. % string


### PR DESCRIPTION
An attempt to use webmachine tracing crashed due to the wrq:response_code/1
function not handling custom reason phrases introduced in commit
dedc5736. Add a new clause for that function to handle custom reason
phrases.
