### PR TITLE
Treat empty content-type header value the same as if it were undefined

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -589,10 +589,13 @@ decision(v3p11) ->
     end.
 
 accept_helper() ->
-    CT = case get_header_val("Content-Type") of
-             undefined -> "application/octet-stream";
-             Other -> Other
-         end,
+    accept_helper(get_header_val("Content-Type")).
+
+accept_helper(undefined) ->
+    accept_helper("application/octet-stream");
+accept_helper([]) ->
+    accept_helper("application/octet-stream");
+accept_helper(CT) ->
     {MT, MParams} = webmachine_util:media_type_to_detail(CT),
     wrcall({set_metadata, 'mediaparams', MParams}),
     case [Fun || {Type,Fun} <-


### PR DESCRIPTION
Clients can send a content-type header with no value and this change adds
handling to treat that case the same as if the header were undefined. This
allows request processing to proceed instead of resulting in a 500 error
response to the user.
