### PR TITLE
Reduce request overhead

### DIFF
--- a/include/wm_reqstate.hrl
+++ b/include/wm_reqstate.hrl
@@ -1,5 +1,5 @@
 -record(wm_reqstate, {socket=undefined,
-                   metadata=dict:new(),
+                   metadata=orddict:new(),
                    range=undefined,
                    peer=undefined,
                    reqdata=undefined,

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -204,7 +204,7 @@ try_path_binding([PathSpec|Rest], PathTokens, HostRemainder, Port, HostBindings,
         {ok, Remainder, NewBindings, Depth} ->
             AppRoot = calculate_app_root(Depth + ExtraDepth),
             StringPath = reconstitute(Remainder),
-            PathInfo = dict:from_list(NewBindings),
+            PathInfo = orddict:from_list(NewBindings),
             RD1 =
                 case RD of
                     testing_ignore_dialyzer_warning_here ->

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -202,7 +202,7 @@ call({get_resp_header, HdrName}, {?MODULE, ReqState}) ->
                 wrq:resp_headers(ReqState#wm_reqstate.reqdata)),
     {Reply, ReqState};
 call(get_path_info, {?MODULE, ReqState}) ->
-    PropList = dict:to_list(wrq:path_info(ReqState#wm_reqstate.reqdata)),
+    PropList = orddict:to_list(wrq:path_info(ReqState#wm_reqstate.reqdata)),
     {PropList, ReqState};
 call({get_path_info, Key}, {?MODULE, ReqState}) ->
     {wrq:path_info(Key, ReqState#wm_reqstate.reqdata), ReqState};
@@ -268,13 +268,13 @@ call(has_resp_body, {?MODULE, ReqState}) ->
             end,
     {Reply, ReqState};
 call({get_metadata, Key}, {?MODULE, ReqState}) ->
-    Reply = case dict:find(Key, ReqState#wm_reqstate.metadata) of
+    Reply = case orddict:find(Key, ReqState#wm_reqstate.metadata) of
                 {ok, Value} -> Value;
                 error -> undefined
             end,
     {Reply, ReqState};
 call({set_metadata, Key, Value}, {?MODULE, ReqState}) ->
-    NewDict = dict:store(Key, Value, ReqState#wm_reqstate.metadata),
+    NewDict = orddict:store(Key, Value, ReqState#wm_reqstate.metadata),
     {ok, ReqState#wm_reqstate{metadata=NewDict}};
 call(path_tokens, {?MODULE, ReqState}) ->
     {wrq:path_tokens(ReqState#wm_reqstate.reqdata), ReqState};
@@ -284,7 +284,7 @@ call(req_qs, {?MODULE, ReqState}) ->
     {wrq:req_qs(ReqState#wm_reqstate.reqdata), ReqState};
 call({load_dispatch_data, PathProps, HostTokens, Port,
       PathTokens, AppRoot, DispPath}, {?MODULE, ReqState}) ->
-    PathInfo = dict:from_list(PathProps),
+    PathInfo = orddict:from_list(PathProps),
     NewState = ReqState#wm_reqstate{reqdata=wrq:load_dispatch_data(
                         PathInfo,HostTokens,Port,PathTokens,AppRoot,
                         DispPath,ReqState#wm_reqstate.reqdata)},

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -926,7 +926,7 @@ header_test() ->
 metadata_test() ->
     Key = "webmachine",
     Value = "eunit",
-    {ok, ReqState} = set_metadata(Key, Value, #wm_reqstate{metadata=dict:new()}),
+    {ok, ReqState} = set_metadata(Key, Value, #wm_reqstate{metadata=orddict:new()}),
     ?assertEqual({Value, ReqState}, get_metadata(Key, ReqState)).
 
 peer_test() ->

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -70,7 +70,7 @@ default(post_is_create) ->
 default(create_path) ->
     undefined;
 default(base_uri) ->
-	undefined;
+        undefined;
 default(process_post) ->
     false;
 default(language_available) ->
@@ -111,18 +111,19 @@ default(_) ->
 
 wrap(Mod, Args, {?MODULE, _, _, _, _}) ->
     wrap(Mod, Args).
+
 wrap(Mod, Args) ->
     case Mod:init(Args) of
         {ok, ModState} ->
             {ok, webmachine_resource:new(Mod, ModState,
-                           dict:from_list(Mod:module_info(exports)), false)};
+                           orddict:from_list(Mod:module_info(exports)), false)};
         {{trace, Dir}, ModState} ->
             {ok, File} = open_log_file(Dir, Mod),
             log_decision(File, v3b14),
             log_call(File, attempt, Mod, init, Args),
             log_call(File, result, Mod, init, {{trace, Dir}, ModState}),
             {ok, webmachine_resource:new(Mod, ModState,
-                dict:from_list(Mod:module_info(exports)), File)};
+                orddict:from_list(Mod:module_info(exports)), File)};
         _ ->
             {stop, bad_init_arg}
     end.
@@ -156,7 +157,7 @@ handle_wm_call(Fun, ReqData, {?MODULE,R_Mod,R_ModState,R_ModExports,R_Trace}=Req
         no_default ->
             resource_call(Fun, ReqData, Req);
         Default ->
-            case dict:is_key(Fun, R_ModExports) of
+            case orddict:is_key(Fun, R_ModExports) of
                 true ->
                     resource_call(Fun, ReqData, Req);
                 false ->

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -145,9 +145,11 @@ do(Fun, ReqProps, {?MODULE, R_Mod, _, R_ModExports, R_Trace}=Req)
                    empty -> RState0;
                    X -> X
                end,
+    %% Do not need the embedded state anymore
+    TrimData = ReqData#wm_reqdata{wm_state=undefined},
     {Reply,
      webmachine_resource:new(R_Mod, NewModState, R_ModExports, R_Trace),
-     ReqState#wm_reqstate{reqdata=ReqData}}.
+     ReqState#wm_reqstate{reqdata=TrimData}}.
 
 handle_wm_call(Fun, ReqData, {?MODULE,R_Mod,R_ModState,R_ModExports,R_Trace}=Req) ->
     case default(Fun) of

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -51,7 +51,7 @@ create(Method,Scheme,Version,RawPath,Headers) ->
       % Stolen from R13B03 inet_drv.c's TCP_MAX_PACKET_SIZE definition
       max_recv_hunk=(64*(1024*1024)),
       app_root="defined_in_load_dispatch_data",
-      path_info=dict:new(),
+      path_info=orddict:new(),
       path_tokens=defined_in_load_dispatch_data,
       disp_path=defined_in_load_dispatch_data,
       resp_redirect=false, resp_headers=mochiweb_headers:empty(),
@@ -152,7 +152,7 @@ resp_body(_RD = #wm_reqdata{resp_body=RespB}) -> iolist_to_binary(RespB).
 %% --
 
 path_info(Key, RD) when is_atom(Key) ->
-    case dict:find(Key, path_info(RD)) of
+    case orddict:find(Key, path_info(RD)) of
         {ok, Value} when is_list(Value); is_integer(Value) ->
             Value; % string (for host or path match)
                    % or integer (for port match)


### PR DESCRIPTION
This pull request is composed of two changes intended to reduce the overhead of webmachine requests.
1. Only keep the request state information that is embedded into the request data record as long as necessary. This avoids the overhead of large amounts of unused and repetitive request state and request data record information being aggregately accumulated during the lifetime of a single request.
2. The dict type wastes a good deal of space and is not the most efficient type when total items is relatively small. The uses of dict are cases where the size should be relatively small so using orddict instead should have space and performance benefits.

[Benchmarking results](https://gist.github.com/4200638) using a cluster of 4 virtual machines running Ubuntu 11.10 and Riak 1.2 and using the `riak_kv_yessir_backend` show no significant change in request latencies or request throughput when using these changes to webmachine. The `yessir` backend was used to eliminate the variable of disk I/O for doing throughput and latency comparisons.
