### PR TITLE
Avoid localtime to universaltime

### DIFF
--- a/demo/src/webmachine_demo_resource.erl
+++ b/demo/src/webmachine_demo_resource.erl
@@ -5,7 +5,7 @@
 -module(webmachine_demo_resource).
 -author('Justin Sheehy <justin@basho.com>').
 -export([init/1, to_html/2, to_text/2, content_types_provided/2,
-         is_authorized/2, generate_etag/2, expires/2]).
+         is_authorized/2, generate_etag/2, expires/2, last_modified/2]).
 
 -include_lib("webmachine/include/webmachine.hrl").
 
@@ -44,5 +44,8 @@ is_authorized(ReqData, Context) ->
     end.
 
 expires(ReqData, Context) -> {{{2021,1,1},{0,0,0}}, ReqData, Context}.
+
+last_modified(ReqData, Context) ->
+    {calendar:now_to_universal_time(os:timestamp()), ReqData, Context}.
 
 generate_etag(ReqData, Context) -> {wrq:raw_path(ReqData), ReqData, Context}.

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -79,8 +79,7 @@ respond({304, _ReasonPhrase}=CodeAndPhrase, Resource, EndTime) ->
         undefined -> nop;
         Exp ->
             wrcall({set_resp_header, "Expires",
-                    httpd_util:rfc1123_date(
-                      calendar:universal_time_to_local_time(Exp))})
+                    webmachine_util:rfc1123_date(Exp)})
     end,
     finish_response(CodeAndPhrase, Resource, EndTime);
 respond(CodeAndPhrase, Resource, EndTime) ->
@@ -546,15 +545,13 @@ decision(v3o18) ->
                 undefined -> nop;
                 LM ->
                     wrcall({set_resp_header, "Last-Modified",
-                           httpd_util:rfc1123_date(
-                             calendar:universal_time_to_local_time(LM))})
+                            webmachine_util:rfc1123_date(LM)})
             end,
             case resource_call(expires) of
                 undefined -> nop;
                 Exp ->
                     wrcall({set_resp_header, "Expires",
-                           httpd_util:rfc1123_date(
-                              calendar:universal_time_to_local_time(Exp))})
+                            webmachine_util:rfc1123_date(Exp)})
             end,
             F = hd([Fun || {Type,Fun} <- resource_call(content_types_provided),
                            CT =:= webmachine_util:format_content_type(Type)]),

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -20,6 +20,7 @@
 -module(webmachine_util).
 -export([guess_mime/1]).
 -export([convert_request_date/1, compare_ims_dates/2]).
+-export([rfc1123_date/1]).
 -export([choose_media_type/2, format_content_type/1]).
 -export([choose_charset/2]).
 -export([choose_encoding/2]).
@@ -51,6 +52,13 @@ compare_ims_dates(D1, D2) ->
     GD1 = calendar:datetime_to_gregorian_seconds(D1),
     GD2 = calendar:datetime_to_gregorian_seconds(D2),
     GD1 > GD2.
+
+%% @doc Convert tuple style GMT datetime to RFC1123 style one
+rfc1123_date({{YYYY, MM, DD}, {Hour, Min, Sec}}) ->
+    DayNumber = calendar:day_of_the_week({YYYY, MM, DD}),
+    lists:flatten(io_lib:format("~s, ~2.2.0w ~3.s ~4.4.0w ~2.2.0w:~2.2.0w:~2.2.0w GMT",
+                                [httpd_util:day(DayNumber), DD, httpd_util:month(MM),
+                                 YYYY, Hour, Min, Sec])).
 
 %% @spec guess_mime(string()) -> string()
 %% @doc  Guess the mime type of a file by the extension of its filename.
@@ -466,6 +474,10 @@ compare_ims_dates_test() ->
     Early = {{2009,12,30},{13,39,02}},
     ?assertEqual(true, compare_ims_dates(Late, Early)),
     ?assertEqual(false, compare_ims_dates(Early, Late)).
+
+rfc1123_date_test() ->
+    ?assertEqual("Thu, 11 Jul 2013 04:33:19 GMT",
+                 rfc1123_date({{2013, 7, 11}, {4, 33, 19}})).
 
 guess_mime_test() ->
     TextTypes = [".html",".css",".htc",".manifest",".txt"],


### PR DESCRIPTION
httpd_util:rfc1123_date/1 uses internally erlang:localtime_to_universaltime/2
with 2nd argument of true. The function takes msec or tens of msec
depending on concurrency.

Usage of httpd_util:rfc1123_date/1 in webmachine_decision_core is
tuple style GMT -> tuple-style localtime -> RFC 1123 string (also GMT).
New utility function webmachine_util:rfc1123_date converts
tuple style GMT to RFC 1123 string directly.
