### PR TITLE
Use rebar to define new_hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 ERL          ?= erl
 APP          := webmachine
 
-VSN := $(shell erl -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), init:stop().' | grep 'R' | sed -e 's,R\(..\)B.*,\1,')
-NEW_HASH := $(shell expr $(VSN) \>= 16)
-
 .PHONY: deps
 
 all: deps
@@ -25,10 +22,6 @@ distclean: clean
 edoc:
 	@$(ERL) -noshell -run edoc_run application '$(APP)' '"."' '[{preprocess, true},{includes, ["."]}]'
 
-test: all	
-ifeq ($(NEW_HASH),1)
-	@(./rebar skip_deps=true -Dnew_hash eunit)
-else
+test: all
 	@(./rebar skip_deps=true eunit)
-endif
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,11 @@
+case erlang:system_info(otp_release) >= "R16B01" of
+    true  ->
+        HashDefine = [{d,new_hash}],
+        case lists:keysearch(erl_opts, 1, CONFIG) of
+            {value, {erl_opts, Opts}} ->
+                lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
+            false ->
+                CONFIG ++ [{erl_opts, HashDefine}]
+        end;
+    false -> CONFIG
+end.


### PR DESCRIPTION
A rebar.config.script checks the OTP version and defines new_hash
instead of having the Makefile doing it. This works better when running
R16 and Webmachine in itself is a dependency.
