### PR TITLE
Rework Webmachine error logging to use the built-in log handler

### DIFF
--- a/demo/src/webmachine_demo.erl
+++ b/demo/src/webmachine_demo.erl
@@ -16,19 +16,21 @@ ensure_started(App) ->
 start_link() ->
     ensure_started(crypto),
     ensure_started(mochiweb),
-    application:set_env(webmachine, webmachine_logger_module, 
-                        webmachine_logger),
+    LogHandlers = [{webmachine_access_log_handler, ["priv/log"]},
+                   {webmachine_error_log_handler, ["priv/log"]}],
+    application:set_env(webmachine, log_handlers, LogHandlers),
     ensure_started(webmachine),
     webmachine_demo_sup:start_link().
 
 %% @spec start() -> ok
 %% @doc Start the webmachine_demo server.
 start() ->
-    ensure_started(inets), 
+    ensure_started(inets),
     ensure_started(crypto),
     ensure_started(mochiweb),
-    application:set_env(webmachine, webmachine_logger_module, 
-                        webmachine_logger),
+    LogHandlers = [{webmachine_access_log_handler, ["priv/log"]},
+                   {webmachine_error_log_handler, ["priv/log"]}],
+    application:set_env(webmachine, log_handlers, LogHandlers),
     ensure_started(webmachine),
     application:start(webmachine_demo).
 

--- a/demo/src/webmachine_demo_sup.erl
+++ b/demo/src/webmachine_demo_sup.erl
@@ -47,7 +47,6 @@ init([]) ->
     WebConfig = [
                  {ip, Ip},
                  {port, 8000},
-                 {log_dir, "priv/log"},
                  {dispatch, Dispatch}],
     Web = {webmachine_mochiweb,
            {webmachine_mochiweb, start, [WebConfig]},

--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -14,9 +14,9 @@
 %% specific language governing permissions and limitations
 %% under the License.
 
-%% @doc Default log handler for webmachine
+%% @doc Default access log handler for webmachine
 
--module(webmachine_log_handler).
+-module(webmachine_access_log_handler).
 
 -behaviour(gen_event).
 
@@ -110,12 +110,16 @@ format_req(#wm_log_data{method=Method,
             undefined -> "";
             U -> U
         end,
-    fmt_alog(Time, Peer, User, atom_to_list(Method), Path, Version,
+    fmt_alog(Time, Peer, User, Method, Path, Version,
              Status, Length, Referer, UserAgent).
 
+fmt_alog(Time, Ip, User, Method, Path, Version,
+         Status,  Length, Referer, UserAgent) when is_atom(Method) ->
+    fmt_alog(Time, Ip, User, atom_to_list(Method), Path, Version,
+             Status, Length, Referer, UserAgent);
 fmt_alog(Time, Ip, User, Method, Path, {VM,Vm},
-         Status,  Length, Referrer, UserAgent) ->
+         Status,  Length, Referer, UserAgent) ->
     [webmachine_log:fmt_ip(Ip), " - ", User, [$\s], Time, [$\s, $"], Method, " ", Path,
      " HTTP/", integer_to_list(VM), ".", integer_to_list(Vm), [$",$\s],
-     Status, [$\s], Length, [$\s,$"], Referrer,
+     Status, [$\s], Length, [$\s,$"], Referer,
      [$",$\s,$"], UserAgent, [$",$\n]].

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -234,18 +234,18 @@ run_guard(Fun, RD) when is_function(Fun) ->
     try
         Fun(RD) == true
     catch _Type : Msg ->
-            error_logger:error_msg("Error running guard ~p: ~p~n", [Fun, Msg]),
+            webmachine_log:log_error(["Error running guard ", Fun, ": ", Msg, $\n]),
             throw({error_running_guard, Fun, Msg})
     end;
 run_guard({Mod, Fun}, RD) ->
     try
         Mod:Fun(RD) == true
     catch _Type : Msg ->
-            error_logger:error_msg("Error running guard ~p:~p/1: ~p~n", [Mod, Fun, Msg]),
+            webmachine_log:log_error(["Error running guard ", Mod, $:, Fun, "/1: ", Msg, $\n]),
             throw({error_running_guard, {Mod, Fun}, Msg})
     end;
 run_guard(Other, _) ->
-    error_logger:error_msg("Unknown guard type in webmachine_dispatcher: ~p~n", [Other]),
+    webmachine_log:log_error(["Unknown guard type in webmachine_dispatcher: ", Other, $\n]),
     throw({unknown_guard_type, Other}).
 
 bind([], [], Bindings, Depth) ->

--- a/src/webmachine_error_handler.erl
+++ b/src/webmachine_error_handler.erl
@@ -28,7 +28,7 @@
 render_error(Code, Req, Reason) ->
     case Req:has_response_body() of
         {true,_} ->
-            maybe_log(Req, Reason),
+            maybe_log(Code, Req, Reason),
             Req:response_body();
         {false,_} -> render_error_body(Code, Req:trim_state(), Reason)
     end.
@@ -39,18 +39,17 @@ render_error_body(404, Req, _Reason) ->
 
 render_error_body(500, Req, Reason) ->
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
-    maybe_log(Req, Reason),
+    maybe_log(500, Req, Reason),
     STString = io_lib:format("~p", [Reason]),
     ErrorStart = "<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>",
     ErrorEnd = "</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>",
     ErrorIOList = [ErrorStart,STString,ErrorEnd],
     {erlang:iolist_to_binary(ErrorIOList), ReqState};
 
-render_error_body(501, Req, _Reason) ->
+render_error_body(501, Req, Reason) ->
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
     {Method,_} = Req:method(),
-    error_logger:error_msg("Webmachine does not support method ~p~n",
-                           [Method]),
+    webmachine_log:log_error(501, Req, Reason),
     ErrorStr = io_lib:format("<html><head><title>501 Not Implemented</title>"
                              "</head><body><h1>Not Implemented</h1>"
                              "The server does not support the ~p method.<br>"
@@ -59,10 +58,9 @@ render_error_body(501, Req, _Reason) ->
                              [Method]),
     {erlang:iolist_to_binary(ErrorStr), ReqState};
 
-render_error_body(503, Req, _Reason) ->
+render_error_body(503, Req, Reason) ->
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
-    error_logger:error_msg("Webmachine cannot fulfill"
-                           " the request at this time"),
+    webmachine_log:log_error(503, Req, Reason),
     ErrorStr = "<html><head><title>503 Service Unavailable</title>"
                "</head><body><h1>Service Unavailable</h1>"
                "The server is currently unable to handle "
@@ -86,11 +84,10 @@ render_error_body(Code, Req, Reason) ->
             "<p><hr><address>mochiweb+webmachine web server</address></body></html>"],
     {iolist_to_binary(Body), ReqState}.
 
-maybe_log(_Req, {error, {exit, normal, _Stack}}) ->
+maybe_log(_Code, _Req, {error, {exit, normal, _Stack}}) ->
     %% webmachine_request did an exit(normal), so suppress this
     %% message. This usually happens when a chunked upload is
     %% interrupted by network failure.
     ok;
-maybe_log(Req, Reason) ->
-    {Path,_} = Req:path(),
-    error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, Reason]).
+maybe_log(Code, Req, Reason) ->
+    webmachine_log:log_error(Code, Req, Reason).

--- a/src/webmachine_error_log_handler.erl
+++ b/src/webmachine_error_log_handler.erl
@@ -1,0 +1,112 @@
+%% Copyright (c) 2011-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+%% @doc Default log handler for webmachine
+
+-module(webmachine_error_log_handler).
+
+-behaviour(gen_event).
+
+%% gen_event callbacks
+-export([init/1,
+         handle_call/2,
+         handle_event/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-include("webmachine_logger.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-record(state, {hourstamp, filename, handle}).
+
+-define(FILENAME, "wm_error.log").
+
+%% ===================================================================
+%% gen_event callbacks
+%% ===================================================================
+
+%% @private
+init([BaseDir]) ->
+    webmachine_log:defer_refresh(?MODULE),
+    FileName = filename:join(BaseDir, ?FILENAME),
+    {Handle, DateHour} = webmachine_log:log_open(FileName),
+    {ok, #state{filename=FileName, handle=Handle, hourstamp=DateHour}}.
+
+%% @private
+handle_call({_Label, MRef, get_modules}, State) ->
+    {ok, {MRef, [?MODULE]}, State};
+handle_call({refresh, Time}, State) ->
+    {ok, ok, webmachine_log:maybe_rotate(?MODULE, Time, State)};
+handle_call(_Request, State) ->
+    {ok, ok, State}.
+
+%% @private
+handle_event({log_error, Msg}, State) ->
+    NewState = webmachine_log:maybe_rotate(?MODULE, os:timestamp(), State),
+    FormattedMsg = format_req(error, undefined, undefined, Msg),
+    webmachine_log:log_write(NewState#state.handle, FormattedMsg),
+    {ok, NewState};
+handle_event({log_error, Code, _Req, _Reason}, State) when Code < 500 ->
+    {ok, State};
+handle_event({log_error, Code, Req, Reason}, State) ->
+    NewState = webmachine_log:maybe_rotate(?MODULE, os:timestamp(), State),
+    Msg = format_req(error, Code, Req, Reason),
+    webmachine_log:log_write(NewState#state.handle, Msg),
+    {ok, NewState};
+handle_event({log_info, Msg}, State) ->
+    NewState = webmachine_log:maybe_rotate(?MODULE, os:timestamp(), State),
+    FormattedMsg = format_req(info, undefined, undefined, Msg),
+    webmachine_log:log_write(NewState#state.handle, FormattedMsg),
+    {ok, NewState};
+handle_event(_Event, State) ->
+    {ok, State}.
+
+%% @private
+handle_info(_Info, State) ->
+    {ok, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+format_req(info, undefined, _, Msg) ->
+    ["[info] ", Msg];
+format_req(error, undefined, _, Msg) ->
+    ["[error] ", Msg];
+format_req(error, 501, Req, _) ->
+    {Path, _} = Req:path(),
+    {Method, _} = Req:method(),
+    Reason = "Webmachine does not support method ",
+    ["[error] ", Reason, Method, ": path=", Path, $\n];
+format_req(error, 503, Req, _) ->
+    {Path, _} = Req:path(),
+    Reason = "Webmachine cannot fulfill the request at this time",
+    ["[error] ", Reason, ": path=", Path, $\n];
+format_req(error, _Code, Req, Reason) ->
+    {Path, _} = Req:path(),
+    ["[error] path=", Path, $\x20, Reason, $\n].


### PR DESCRIPTION
Rework error logging to be more flexible. This changes the default error logging behavior from using the Erlang `error_logger` to using an event-based system that allows for more customization and flexibility for users. The default error logging handler provided (`webmachine_error_log_handler`) writes output directly to a file, but it is straightforward to use this module as a template and create a log handler to output via `error_logger` or `lager` or any other means. 

These changes bring error logging in line with how access and performance logging currently work. An advantage of this approach is that it allows error logging to be dynamically added and removed from applications using webmachine. It also allows for multiple error log handlers to be used simultaneously. Finally, it provides the benefit of not explicitly tying error logging  to a single mechanism that may not be the best choice for all applications using webmachine.

This PR changes the name of the access log handler module from `webmachine_log_handler` to the more descriptive `webmachine_access_log_handler`. It also updates the demo application to use the new event-based logging in its initialization. 
