### PR TITLE
Expose the actual socket with wrq:socket

### DIFF
--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -21,7 +21,7 @@
          path_info/1,response_code/1,req_cookie/1,req_qs/1,req_headers/1,
          req_body/1,stream_req_body/2,resp_redirect/1,resp_headers/1,
          resp_body/1,app_root/1,path_tokens/1, host_tokens/1, port/1,
-         base_uri/1,sock/1]).
+         base_uri/1,sock/1,socket/1]).
 -export([path_info/2,get_req_header/2,do_redirect/2,fresh_resp_headers/2,
          get_resp_header/2,set_resp_header/3,set_resp_headers/2,
          set_disp_path/2,set_req_body/2,set_resp_body/2,set_response_code/2,
@@ -37,7 +37,7 @@
 
 
 create(Method,Version,RawPath,Headers) ->
-	create(Method,http,Version,RawPath,Headers).
+    create(Method,http,Version,RawPath,Headers).
 create(Method,Scheme,Version,RawPath,Headers) ->
     create(#wm_reqdata{method=Method,scheme=Scheme,version=Version,
                        raw_path=RawPath,req_headers=Headers,
@@ -85,6 +85,8 @@ version(_RD = #wm_reqdata{version=Version})
 peer(_RD = #wm_reqdata{peer=Peer}) when is_list(Peer) -> Peer.
 
 sock(_RD = #wm_reqdata{sock=Sock}) when is_list(Sock) -> Sock.
+
+socket(_RD = #wm_reqdata{wm_state=#wm_reqstate{socket=Socket}}) -> Socket.
 
 app_root(_RD = #wm_reqdata{app_root=AR}) when is_list(AR) -> AR.
 


### PR DESCRIPTION
This adds wrq:socket/1, which can be used if an app happens to need access to the socket itself, without having to include webmachine records, and without having to message around with element/2.

Originally, I though sock/1 was what I needed, but it turns out to only return the IP address. So if there's another way to do this, that'd be great.

In my case, I'm adding a websocket layer to simple bridge for backends that don't support websockets, and in order to do so, I need to hijack the socket.  While I have it working with a combination of element/2 on the Webmachine Req record, then calling webmachine_request:socket/1 on it, I'd much rather not rely on the record element positioning hack and go with something more "sanctioned".

That said, if what I'm looking for is already available without `element/2` hacks or including the webmachine .hrl files, in my app, I'd love to hear it.  But I figured since this was so quick to implement, that I might as well put in a PR.

I will note that this patch, in its current form, does work for adding a websocket layer onto webmachine with simple bridge (which I'll be putting out publicly in the next few days for folks to kick the tires).

Thanks, and have a great one!
