### PR TITLE
Make sure Reason is a string

### DIFF
--- a/src/webmachine_error_log_handler.erl
+++ b/src/webmachine_error_log_handler.erl
@@ -109,4 +109,6 @@ format_req(error, 503, Req, _) ->
     ["[error] ", Reason, ": path=", Path, $\n];
 format_req(error, _Code, Req, Reason) ->
     {Path, _} = Req:path(),
-    ["[error] path=", Path, $\x20, Reason, $\n].
+    Str = io_lib:format("~p", [Reason]),
+    ["[error] path=", Path, $\x20, Str, $\n].
+


### PR DESCRIPTION
Since 8194983c4686945850b142e3cf330c8795a859b6 when an exception
in the app occured the console had:

Bad value on output port 'efile'

and the error log remained empty. This was due to the tupe not being
converted to string.

With this applied errors correctly show up in the log.
