### PR TITLE
Fixes a fatal edoc error. Changes edoc spec to init_routes/1

### DIFF
--- a/src/webmachine_router.erl
+++ b/src/webmachine_router.erl
@@ -107,7 +107,7 @@ get_routes() ->
 get_routes(Name) ->
     get_dispatch_list(Name).
 
-%% @spec init_routes() -> ok
+%% @spec init_routes([hostmatchterm() | pathmatchterm()]) -> ok
 %% @doc Set the default routes, unless the routing table isn't empty.
 init_routes(DefaultRoutes) ->
     init_routes(default, DefaultRoutes).


### PR DESCRIPTION
The edoc spec for <code>init_routes/1</code> is incorrect, causing a fatal error.

<pre>
computer:webmachine me$ make edoc
./src/webmachine_router.erl, function init_routes/1: at line 110: @spec arity does not match.
edoc: skipping source file './src/webmachine_router.erl': {'EXIT',error}.
edoc: error in doclet 'edoc_doclet': {'EXIT',error}.
edoc: edoc terminated abnormally: error.
make: *** [edoc] Error 1
</pre>


This corrects the issue.
