### PR TITLE
Support IPv6 address literals when parsing Host header

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -52,17 +52,77 @@ dispatch(HostAsString, PathAsString, DispatchList, RD) ->
     try_host_binding(DispatchList, Host, Port, Path, ExtraDepth, RD).
 
 split_host_port(HostAsString, Scheme) ->
-    case string:tokens(HostAsString, ":") of
-        [HostPart, PortPart] ->
-            {split_host(HostPart), list_to_integer(PortPart)};
-        [HostPart] ->
+    case parse_port_from_host(HostAsString) of
+        {HostPart, no_port} ->
             {split_host(HostPart), default_port(Scheme)};
-        [] ->
+        {HostPart, PortPart} ->
+            {split_host(HostPart), list_to_integer(PortPart)};
+        no_host ->
             %% no host header
             {[], default_port(Scheme)};
         _ ->
             %% Invalid host header
             {invalid_host, default_port(Scheme)}
+    end.
+
+parse_port_from_host([]) ->
+    no_host;
+parse_port_from_host(S) ->
+    parse_port_from_host(lists:reverse(S), []).
+
+parse_port_from_host([], Host) ->
+    {Host, no_port};
+parse_port_from_host([C|Rest] = Host0, Acc) when C == $: orelse C == $]->
+    Port = case Acc of
+               [] ->
+                   no_port;
+               P ->
+                   P
+           end,
+    RevHost = case C of
+                  $] ->
+                      Host0;
+                  _ ->
+                      Rest
+           end,
+    Host1 = lists:reverse(RevHost),
+    {Host2, Port2} = handle_unbracketed_ipv6(Host1, Port),
+    Host = Host2,
+    {Host, Port2};
+parse_port_from_host([C|Rest], Acc) ->
+    parse_port_from_host(Rest, [C|Acc]).
+
+%% Attempt naive normalization of degenerate unbracketed ipv6 literals
+%%
+%% IPv6 address literals in URLs (and therefore in the Host header)
+%% should be enclosed in square brackets. See
+%% http://www.ietf.org/rfc/rfc2732.txt. Some HTTP clients will
+%% incorrectly remove brackets from ipv6 address literals.
+%%
+%% An unbracketed ipv6 address literal is degenerate in URLs since you
+%% can't reliably parse it for a port. We "handle" this case by
+%% assuming default port and adding brackets.
+handle_unbracketed_ipv6("[" ++ _Rest = Host, Port) ->
+    {Host, Port};
+handle_unbracketed_ipv6(Host, Port) ->
+    case is_ipv6_addr(Host) of
+        false ->
+            {Host, Port};
+        true ->
+            %% we have an unbracketed ipv6 literal. We assume default
+            %% port and add brackets to normalize.  Port here is just
+            %% the last group, may be part of address.
+            {"[" ++ Host ++ ":" ++ Port ++ "]", no_port}
+    end.
+
+%% Return true if `Host' is an IPv6 address literal. Assumes port has
+%% been removed and simply detects precense of `:'.
+is_ipv6_addr(Host) ->
+    case string:chr(Host, $:) of
+        0 ->
+            false;
+        _ ->
+            true
     end.
 
 split_host(HostAsString) ->
@@ -304,6 +364,21 @@ split_host_port_test() ->
                  split_host_port("foo.bar.baz", https)),
     ?assertEqual({["foo","bar","baz"], 1234},
                  split_host_port("foo.bar.baz:1234", https)).
+
+split_host_port_ipv6_test_() ->
+    Tests = [% {Input, Expect}
+             {"[::1]", {["[::1]"], 80}},
+             {"[::1]:4321", {["[::1]"], 4321}},
+             {"[fd83:4e09:e1b6:e2a3::106]", {["[fd83:4e09:e1b6:e2a3::106]"], 80}},
+             {"[fd83:4e09:e1b6:e2a3::106]:4321", {["[fd83:4e09:e1b6:e2a3::106]"], 4321}},
+             %% degenerate case of ipv6 literals without brackets
+             {"::1", {["[::1]"], 80}},
+             {"fd83:4e09:e1b6:e2a3::106", {["[fd83:4e09:e1b6:e2a3::106]"], 80}},
+             %% unbracketed with port not supported. This documents what to expect.
+             {"::1:4321", {["[::1:4321]"], 80}}
+            ],
+    [ ?_assertEqual({Input, Expect}, {Input, split_host_port(Input, http)})
+      || {Input, Expect} <- Tests ].
 
 %% port binding
 bind_port_simple_match_test() ->

--- a/test/wm_echo_host_header.erl
+++ b/test/wm_echo_host_header.erl
@@ -1,0 +1,38 @@
+%%
+%%
+%%    Licensed under the Apache License, Version 2.0 (the "License");
+%%    you may not use this file except in compliance with the License.
+%%    You may obtain a copy of the License at
+%%
+%%        http://www.apache.org/licenses/LICENSE-2.0
+%%
+%%    Unless required by applicable law or agreed to in writing, software
+%%    distributed under the License is distributed on an "AS IS" BASIS,
+%%    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%    See the License for the specific language governing permissions and
+%%    limitations under the License.
+
+-module(wm_echo_host_header).
+
+-export([
+         init/1,
+         to_html/2,
+         parse_body/1
+        ]).
+
+-include_lib("webmachine/include/webmachine.hrl").
+
+init([]) -> {ok, undefined}.
+
+to_html(Req, State) ->
+    HostVal = wrq:get_req_header("host", Req),
+    HostTokens = string:join(wrq:host_tokens(Req), "."),
+    Body = "Host\t" ++ HostVal ++
+        "\nHostTokens\t" ++ HostTokens ++ "\n",
+    {Body, Req, State}.
+
+%% Transform the body returned by this resource into a proplist for
+%% testing.
+parse_body(Body) ->
+    Lines = re:split(Body, "\n"),
+    [ erlang:list_to_tuple(re:split(Line, "\t")) || Line <- Lines ].

--- a/test/wm_integration_test.erl
+++ b/test/wm_integration_test.erl
@@ -1,0 +1,105 @@
+%%
+%%
+%%    Licensed under the Apache License, Version 2.0 (the "License");
+%%    you may not use this file except in compliance with the License.
+%%    You may obtain a copy of the License at
+%%
+%%        http://www.apache.org/licenses/LICENSE-2.0
+%%
+%%    Unless required by applicable law or agreed to in writing, software
+%%    distributed under the License is distributed on an "AS IS" BASIS,
+%%    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%    See the License for the specific language governing permissions and
+%%    limitations under the License.
+-module(wm_integration_test).
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-compile([export_all]).
+
+integration_test_() ->
+    {foreach,
+     %% Setup
+     fun() ->
+             ibrowse:start(),
+             DL = [{["wm_echo_host_header", '*'], wm_echo_host_header, []}],
+             %% Listen on both ipv4 and ipv6 so we can test both.
+             Ctx = wm_integration_test_util:start(?MODULE, "::0", DL),
+             Ctx
+     end,
+     %% Cleanup
+     fun(Ctx) ->
+             wm_integration_test_util:stop(Ctx)
+     end,
+     %% Test functions provided with context from setup
+     [fun(Ctx) ->
+              {spawn, {with, Ctx, integration_tests()}}
+      end]}.
+
+integration_tests() ->
+    [fun test_host_header_localhost/1,
+     fun test_host_header_127/1,
+     fun test_host_header_ipv6/1,
+     fun test_host_header_ipv6_curl/1].
+
+test_host_header_localhost(Ctx) ->
+    ExpectHost = add_port(Ctx, "localhost"),
+    verify_host_header(Ctx, "localhost", ExpectHost, <<"localhost">>).
+
+test_host_header_127(Ctx) ->
+    ExpectHost = add_port(Ctx, "127.0.0.1"),
+    verify_host_header(Ctx, "127.0.0.1", ExpectHost, <<"127.0.0.1">>).
+
+test_host_header_ipv6(Ctx) ->
+    %% Bare ipv6 addresses must be enclosed in square
+    %% brackets. ibrowse does the right thing in parsing the URL, but
+    %% does not set the Host header correctly where it adds the bare
+    %% host rather than the bracketed version.
+    %%
+    %% It is likely there are other HTTP clients that will make send
+    %% such a Host header, it is worth testing that we handle it
+    %% reasonably.
+    ExpectHost = add_port(Ctx, "::1"),
+    ExpectTokens = <<"[", ExpectHost/binary, "]">>,
+    verify_host_header(Ctx, "[::1]", ExpectHost, ExpectTokens).
+
+test_host_header_ipv6_curl(Ctx) ->
+    %% curl has the desired client behavior for ipv6
+    case os:find_executable("curl") of
+        false ->
+            ?debugMsg("curl not found: skipping test_host_header_ipv6_curl");
+        _ ->
+            Port = wm_integration_test_util:get_port(Ctx),
+            P = erlang:integer_to_list(Port),
+            Cmd = "curl -gs http://[::1]:" ++ P ++ "/wm_echo_host_header",
+            Got = wm_echo_host_header:parse_body(erlang:list_to_binary(os:cmd(Cmd))),
+            ?assertEqual(add_port(Ctx, "[::1]"), proplists:get_value(<<"Host">>, Got)),
+            ?assertEqual(<<"[::1]">>, proplists:get_value(<<"HostTokens">>, Got))
+    end.
+
+url(Ctx, Host, Path) ->
+    Port = erlang:integer_to_list(wm_integration_test_util:get_port(Ctx)),
+    "http://" ++ Host ++ ":" ++ Port ++ slash(Path).
+
+slash("/" ++ _Rest = Path) ->
+    Path;
+slash(Path) ->
+    "/" ++ Path.
+
+add_port(Ctx, Host) ->
+    Port = wm_integration_test_util:get_port(Ctx),
+    erlang:iolist_to_binary([Host, ":", erlang:integer_to_list(Port)]).
+
+%% TODO: wm crashes if multiple Host headers are sent
+
+verify_host_header(Ctx, Host, ExpectHostHeader, ExpectHostTokens) ->
+    URL = url(Ctx, Host, "wm_echo_host_header"),
+    {ok, Status, _Headers, Body} = ibrowse:send_req(URL, [], get, [], []),
+    ?assertEqual("200", Status),
+    Got = wm_echo_host_header:parse_body(Body),
+    ?assertEqual(ExpectHostHeader, proplists:get_value(<<"Host">>, Got)),
+    ?assertEqual(ExpectHostTokens, proplists:get_value(<<"HostTokens">>, Got)).
+
+-endif.


### PR DESCRIPTION
IPv6 address literals are enclosed in square brackets when used in a
URL [1](http://www.ietf.org/rfc/rfc2732.txt). This patch allows the host/port parsing in dispatch/4 to
handle such values.

The adjusted parsing implementation attempts to normalize ipv6
literals and adds brackets if they are missing. Some clients (including
ibrowse 4.0.1) send a Host header with a non-bracketed address. With
the normalization, the value returned by wrq:host_tokens/1 will have
brackets if it is an ipv6 literal.

[update: new patch behavior treats unbracketed ipv6 addresses as always on default port and keeps the address "whole"]

When a non-bracketed Host header containing an ipv6 address literal is
encountered, the right thing will happen if an explicit port is given
in the header value. Otherwise, the last section of the ipv6 address
will be parsed as the port. Since the client is sending an incorrect,
it seemed not worth adding additional workarounds for this case.

Finally, this patch introduces test/wm_integration_test and a minimal
resource module to verify the Host header and host tokens
behavior. ibrowse and curl are used to make HTTP requests for
testing. In R15, httpc is unable to make ipv6 requests. Curl used as
it gives the correct behavior -- the test is guarded and will be
skipped without failure if no curl executable is found on PATH.
