### PR TITLE
Wip fix logger

### DIFF
--- a/include/webmachine_logger.hrl
+++ b/include/webmachine_logger.hrl
@@ -1,7 +1,10 @@
+%% method will be an atom only for valid HTTP methods and a string otherwise,
+%% see erlang:decode_packet documentation
 -record(wm_log_data,
         {resource_module :: atom(),
          start_time :: tuple(),
-         method :: atom(),
+         method :: atom() | string() | binary(),
+
          headers,
          peer,
          sock,


### PR DESCRIPTION
`webmachine_perf_log_handler` would crash if when logging a non standard HTTP method. For example:

```
curl -XFOO http://localhost:8000
```

would crash the handler with `{badarg, [{erlang, atom_to_list, ["FOO"]}, ...`

This fixes it and also fixes the imprecise typing of the `wm_log_data` record
