### PR TITLE
replace use of now() with os:timestamp(), to remove some lock contention

### DIFF
--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -61,7 +61,7 @@ new_request(mochiweb, Request) ->
     ReqData = wrq:set_sock(Sock,
                            wrq:set_peer(Peer,
                                         ReqState#wm_reqstate.reqdata)),
-    LogData = #wm_log_data{start_time=now(),
+    LogData = #wm_log_data{start_time=os:timestamp(),
                            method=Method,
                            headers=Headers,
                            peer=Peer,

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -63,7 +63,7 @@ respond(Code) when is_integer(Code) ->
     respond({Code, undefined});
 respond({_, _}=CodeAndPhrase) ->
     Resource = get(resource),
-    EndTime = now(),
+    EndTime = os:timestamp(),
     respond(CodeAndPhrase, Resource, EndTime).
 
 respond({Code, _ReasonPhrase}=CodeAndPhrase, Resource, EndTime)
@@ -104,7 +104,7 @@ error_response(Reason) ->
 
 error_response(Code, Reason) ->
     Resource = get(resource),
-    EndTime = now(),
+    EndTime = os:timestamp(),
     error_response({Code, undefined}, Reason, Resource, EndTime).
 
 error_response({Code, _}=CodeAndPhrase, Resource, EndTime) ->

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -271,7 +271,7 @@ call({send_response, {Code, ReasonPhrase}=CodeAndReason}, Req) when is_integer(C
                 send_response(CodeAndReason, Req)
         end,
     LogData = NewState#wm_reqstate.log_data,
-    NewLogData = LogData#wm_log_data{finish_time=now()},
+    NewLogData = LogData#wm_log_data{finish_time=os:timestamp()},
     {Reply, NewState#wm_reqstate{log_data=NewLogData}};
 call(resp_body, {?MODULE, ReqState}) ->
     {wrq:resp_body(ReqState#wm_reqstate.reqdata), ReqState};

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -246,7 +246,7 @@ log_decision(File, DecisionID) ->
     io:format(File, "{decision, ~p}.~n", [DecisionID]).
 
 open_log_file(Dir, Mod) ->
-    Now = {_,_,US} = now(),
+    Now = {_,_,US} = os:timestamp(),
     {{Y,M,D},{H,I,S}} = calendar:now_to_universal_time(Now),
     Filename = io_lib:format(
                  "~s/~p-~4..0B-~2..0B-~2..0B"


### PR DESCRIPTION
When doing some performance analysis with a lock-counting vm I notice a bit of contention based on the use of now().  os:timestamp() should work as well in the cases I changes as far as I can tell (also tested out fine in my production cluster.
