### PR TITLE
Fix rebar.config.script for Erlang/OTP 17(rc1)

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,5 @@
-case erlang:system_info(otp_release) =< "R15B01" of
+OtpVersion = erlang:system_info(otp_release). % R17* -> "17"
+case string:len(OtpVersion) > 3 andalso OtpVersion =< "R15B01" of
     true  ->
         HashDefine = [{d,old_hash}],
         case lists:keysearch(erl_opts, 1, CONFIG) of


### PR DESCRIPTION
Beginning from R17, what is returned by `erlang`s `system_info(otp_release)` no longer follows the old schema but simply returns `"17"`.  This makes the `rebar.config.script` check for the version turn _on_ `old_hash`, which really is not what we want. :)

This change works around this issue (while I'm not sure if it's the most beautiful way to do that) by checking for the string length first.

More details on the recent version number decisions: https://groups.google.com/d/msg/erlang-programming/C--8S_0bPME/1tIq4jn118gJ
