### PR TITLE
fix version check in rebar.config.script for 17.0

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,11 +1,19 @@
-case erlang:system_info(otp_release) =< "R15B01" of
-    true  ->
-        HashDefine = [{d,old_hash}],
-        case lists:keysearch(erl_opts, 1, CONFIG) of
-            {value, {erl_opts, Opts}} ->
-                lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
-            false ->
-                CONFIG ++ [{erl_opts, HashDefine}]
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+
+case erlang:system_info(otp_release) of
+     "R"++_=RVersion ->
+        case RVersion =< "R15B01" of
+            true  ->
+                HashDefine = [{d,old_hash}],
+                case lists:keysearch(erl_opts, 1, CONFIG) of
+                    {value, {erl_opts, Opts}} ->
+                        lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
+                    false ->
+                        CONFIG ++ [{erl_opts, HashDefine}]
+                end;
+            false -> CONFIG
         end;
-    false -> CONFIG
+    _ ->
+        CONFIG
 end.


### PR DESCRIPTION
The version check in rebar.config.script was incorrect for Erlang 17.0.
