### PR TITLE
update ibrowse to 4.0.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,5 +8,5 @@
 {deps,
  [{mochiweb, "1.5.1*", {git, "git://github.com/basho/mochiweb.git", {tag, "1.5.1p7"}}},
   {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-  {ibrowse, "4.0.1", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.1"}}}
+  {ibrowse, "4.0.*", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
  ]}.


### PR DESCRIPTION
Riak CS also uses ibrowse 4.0.2 via [erlcloud](https://github.com/basho/erlcloud) for testing. When [trying to update webmachine](https://github.com/basho/riak_cs/pull/890) it consequently depends on ibrowse 4.0.1, which conflicts against 4.0.2. This pull request updates dependency to 4.0.2, and relieves version requirement as well.

Note: this doesn't block Riak CS work but I'd be happy if this merged before CS 1.5.0 final goes out.
