### PR TITLE
Add request timing option for access logger

### DIFF
--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -34,7 +34,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--record(state, {hourstamp, filename, handle}).
+-record(state, {hourstamp,
+                filename,
+                handle,
+                request_timing=false :: boolean()}).
 
 -define(FILENAME, "access.log").
 
@@ -47,20 +50,40 @@ init([BaseDir]) ->
     {ok,_} = webmachine_log:defer_refresh(?MODULE),
     FileName = filename:join(BaseDir, ?FILENAME),
     {Handle, DateHour} = webmachine_log:log_open(FileName),
-    {ok, #state{filename=FileName, handle=Handle, hourstamp=DateHour}}.
+    {ok, #state{filename=FileName, handle=Handle, hourstamp=DateHour}};
+init([BaseDir, true]) ->
+    {ok,_} = webmachine_log:defer_refresh(?MODULE),
+    FileName = filename:join(BaseDir, ?FILENAME),
+    {Handle, DateHour} = webmachine_log:log_open(FileName),
+    {ok, #state{filename=FileName,
+                handle=Handle,
+                hourstamp=DateHour,
+                request_timing=true}};
+init([BaseDir, _]) ->
+    init([BaseDir]).
 
 %% @private
 handle_call({_Label, MRef, get_modules}, State) ->
     {ok, {MRef, [?MODULE]}, State};
 handle_call({refresh, Time}, State) ->
-    {ok, ok, webmachine_log:maybe_rotate(?MODULE, Time, State)};
+    {NewHour, NewHandle} = webmachine_log:maybe_rotate(?MODULE,
+                                                       State#state.filename,
+                                                       State#state.handle,
+                                                       Time,
+                                                       State#state.hourstamp),
+    {ok, ok, State#state{hourstamp=NewHour, handle=NewHandle}};
 handle_call(_Request, State) ->
     {ok, ok, State}.
 
 %% @private
 handle_event({log_access, LogData}, State) ->
-    NewState = webmachine_log:maybe_rotate(?MODULE, os:timestamp(), State),
-    Msg = format_req(LogData),
+    {NewHour, NewHandle} = webmachine_log:maybe_rotate(?MODULE,
+                                                       State#state.filename,
+                                                       State#state.handle,
+                                                       os:timestamp(),
+                                                       State#state.hourstamp),
+    NewState = State#state{hourstamp=NewHour, handle=NewHandle},
+    Msg = format_req(LogData, NewState#state.request_timing),
     _ = webmachine_log:log_write(NewState#state.handle, Msg),
     {ok, NewState};
 handle_event(_Event, State) ->
@@ -88,7 +111,10 @@ format_req(#wm_log_data{method=Method,
                         path=Path,
                         version=Version,
                         response_code=ResponseCode,
-                        response_length=ResponseLength}) ->
+                        response_length=ResponseLength,
+                        start_time=StartTime,
+                        end_time=EndTime},
+          RequestTiming) ->
     User = "-",
     Time = webmachine_log:fmtnow(),
     Status = case ResponseCode of
@@ -110,8 +136,14 @@ format_req(#wm_log_data{method=Method,
             undefined -> "";
             U -> U
         end,
-    fmt_alog(Time, Peer, User, Method, Path, Version,
-             Status, Length, Referer, UserAgent).
+    case RequestTiming of
+        true ->
+            fmt_alog(Time, Peer, User, Method, Path, Version,
+                     Status, Length, Referer, UserAgent, timer:now_diff(EndTime, StartTime));
+        false ->
+            fmt_alog(Time, Peer, User, Method, Path, Version,
+                     Status, Length, Referer, UserAgent)
+    end.
 
 fmt_alog(Time, Ip, User, Method, Path, Version,
          Status,  Length, Referer, UserAgent) when is_atom(Method) ->
@@ -124,6 +156,17 @@ fmt_alog(Time, Ip, User, Method, Path, {VM,Vm},
      Status, [$\s], Length, [$\s,$"], Referer,
      [$",$\s,$"], UserAgent, [$",$\n]].
 
+fmt_alog(Time, Ip, User, Method, Path, Version,
+         Status,  Length, Referer, UserAgent, ReqDuration) when is_atom(Method) ->
+    fmt_alog(Time, Ip, User, atom_to_list(Method), Path, Version,
+             Status, Length, Referer, UserAgent, ReqDuration);
+fmt_alog(Time, Ip, User, Method, Path, {VM,Vm},
+         Status,  Length, Referer, UserAgent, ReqDuration) ->
+    [webmachine_log:fmt_ip(Ip), " - ", User, [$\s], Time, [$\s, $"], Method, " ", Path,
+     " HTTP/", integer_to_list(VM), ".", integer_to_list(Vm), [$",$\s],
+     Status, [$\s], Length, [$\s,$"], Referer,
+     [$",$\s,$"], UserAgent, [$",$\s], integer_to_list(ReqDuration), [$\n]].
+
 
 -ifdef(TEST).
 
@@ -135,7 +178,7 @@ non_standard_method_test() ->
                            version={1,1},
                            response_code=501,
                            response_length=1234},
-    LogEntry = format_req(LogData),
+    LogEntry = format_req(LogData, false),
     ?assert(is_list(LogEntry)),
     ok.
 


### PR DESCRIPTION
Add the ability to specify a boolean configuration parameter to the
webmachine_access_log_handler module to have it include request
duration reporting as part of its log output. The request durations
are reported in microseconds and this option is disabled by default so
that the current default behavior is maintained.
