### PR TITLE
Handle non-atom method names

### DIFF
--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -123,3 +123,20 @@ fmt_alog(Time, Ip, User, Method, Path, {VM,Vm},
      " HTTP/", integer_to_list(VM), ".", integer_to_list(Vm), [$",$\s],
      Status, [$\s], Length, [$\s,$"], Referer,
      [$",$\s,$"], UserAgent, [$",$\n]].
+
+
+-ifdef(TEST).
+
+non_standard_method_test() ->
+    LogData = #wm_log_data{method="FOO",
+                           headers=mochiweb_headers:make([]),
+                           peer={127,0,0,1},
+                           path="/",
+                           version={1,1},
+                           response_code=501,
+                           response_length=1234},
+    LogEntry = format_req(LogData),
+    ?assert(is_list(LogEntry)),
+    ok.
+
+-endif.

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -174,8 +174,12 @@ decision(v3b10) ->
         true ->
             d(v3b9);
         false ->
+            Allowed = [case is_atom(M) of
+                           true -> atom_to_list(M);
+                           false -> M
+                       end || M <- Methods],
             wrcall({set_resp_headers, [{"Allow",
-                   string:join([atom_to_list(M) || M <- Methods], ", ")}]}),
+                   string:join(Allowed, ", ")}]}),
             respond(405)
     end;
 

--- a/src/webmachine_perf_log_handler.erl
+++ b/src/webmachine_perf_log_handler.erl
@@ -104,11 +104,35 @@ format_req(#wm_log_data{resource_module=Mod,
     Length = integer_to_list(ResponseLength),
     TTPD = webmachine_util:now_diff_milliseconds(EndTime, StartTime),
     TTPS = webmachine_util:now_diff_milliseconds(FinishTime, EndTime),
-    fmt_plog(Time, Peer, atom_to_list(Method), Path, Version,
+    fmt_plog(Time, Peer, Method, Path, Version,
              Status, Length, atom_to_list(Mod), integer_to_list(TTPD),
              integer_to_list(TTPS)).
 
+fmt_plog(Time, Ip,  Method0, Path, {VM,Vm}, Status, Length, Mod, TTPD, TTPS)
+  when is_atom(Method0) ->
+    Method = atom_to_list(Method0),
+    fmt_plog(Time, Ip,  Method, Path, {VM,Vm}, Status, Length, Mod, TTPD, TTPS);
 fmt_plog(Time, Ip,  Method, Path, {VM,Vm}, Status, Length, Mod, TTPD, TTPS) ->
     [webmachine_log:fmt_ip(Ip), " - ", [$\s], Time, [$\s, $"], Method, " ", Path,
      " HTTP/", integer_to_list(VM), ".", integer_to_list(Vm), [$",$\s],
      Status, [$\s], Length, " " , Mod, " ", TTPD, " ", TTPS, $\n].
+
+
+-ifdef(TEST).
+
+non_standard_method_test() ->
+    LogData = #wm_log_data{resource_module=foo,
+                           start_time=now(),
+                           method="FOO",
+                           peer={127,0,0,1},
+                           path="/",
+                           version={1,1},
+                           response_code=501,
+                           response_length=1234,
+                           end_time=now(),
+                           finish_time=now()},
+    LogEntry = format_req(LogData),
+    ?assert(is_list(LogEntry)),
+    ok.
+
+-endif.

--- a/src/wmtrace_resource.erl
+++ b/src/wmtrace_resource.erl
@@ -269,8 +269,11 @@ base_decision_name(Decision) ->
     end.
 
 encode_request(ReqData) when is_record(ReqData, wm_reqdata) ->
-    {struct, [{"method", atom_to_list(
-                           wrq:method(ReqData))},
+    Method = case wrq:method(ReqData) of
+                 M when is_atom(M) -> atom_to_list(M);
+                 M -> M
+             end,
+    {struct, [{"method", Method},
               {"path", wrq:raw_path(ReqData)},
               {"headers", encode_headers(wrq:req_headers(ReqData))},
               {"body", case ReqData#wm_reqdata.req_body of
@@ -349,3 +352,16 @@ tag(Name, Attrs, Content) ->
               Content,
               "</",Name,">"]
      end].
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+non_standard_method_test() ->
+    Method = "FOO",
+    ReqData = wrq:create(Method, http, "/", mochiweb_headers:from_list([])),
+    {struct, Props} = encode_request(ReqData),
+    ?assertMatch({"method",Method}, lists:keyfind("method", 1, Props)),
+    ok.
+
+-endif.


### PR DESCRIPTION
When a request contains a non-standard HTTP method name, Erlang and
mochiweb return it as a string rather than an atom. This caused problems in
several parts of webmachine, including logging and tracing.

Fix all parts of the code that assumed method names were always atoms. Add
new unit tests for the fixed areas.
