### PR TITLE
Change reference to listening port to 8080

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,7 +35,7 @@ make
 ./start.sh
 #+END_SRC
 
-The application will be available at [[http://localhost:8000]].
+The application will be available at [[http://localhost:8080]].
 
 To learn more continue reading [[http://webmachine.basho.com/][here]].
 


### PR DESCRIPTION
The template used by scripts/new_webmachine.sh (wmskel) sets the
listening port to 8080 (in priv/templates/src/wmskel.app.src), not 8000
(as is used in the demo app).
