### PR TITLE
Change to use application:ensure_all_started/1

### DIFF
--- a/demo/src/webmachine_demo.erl
+++ b/demo/src/webmachine_demo.erl
@@ -4,8 +4,8 @@
 -export([start/0, start_link/0, stop/0]).
 
 ensure_started(App) ->
-    case application:start(App) of
-        ok ->
+    case application:ensure_all_started(App) of
+        {ok, _} ->
             ok;
         {error, {already_started, App}} ->
             ok


### PR DESCRIPTION
When running start.sh (in demo/), when mochiweb is then started, a
failure occurs due to ssl not having been started. Using
ensure_all_started/1 rather than start/1 fixes that.
