### PR TITLE
Fix webmachine_demo with refactored ensure_all_started function

### DIFF
--- a/demo/src/webmachine_demo.erl
+++ b/demo/src/webmachine_demo.erl
@@ -3,35 +3,22 @@
 -author('Justin Sheehy <justin@@basho.com>').
 -export([start/0, start_link/0, stop/0]).
 
-ensure_started(App) ->
-    case application:start(App) of
-        ok ->
-            ok;
-        {error, {already_started, App}} ->
-            ok
-    end.
-
 %% @spec start_link() -> {ok,Pid::pid()}
 %% @doc Starts the app for inclusion in a supervisor tree
 start_link() ->
-    ensure_started(crypto),
-    ensure_started(mochiweb),
     LogHandlers = [{webmachine_access_log_handler, ["priv/log"]},
                    {webmachine_error_log_handler, ["priv/log"]}],
     application:set_env(webmachine, log_handlers, LogHandlers),
-    ensure_started(webmachine),
+    webmachine_util:ensure_all_started(webmachine),
     webmachine_demo_sup:start_link().
 
 %% @spec start() -> ok
 %% @doc Start the webmachine_demo server.
 start() ->
-    ensure_started(inets),
-    ensure_started(crypto),
-    ensure_started(mochiweb),
     LogHandlers = [{webmachine_access_log_handler, ["priv/log"]},
                    {webmachine_error_log_handler, ["priv/log"]}],
     application:set_env(webmachine, log_handlers, LogHandlers),
-    ensure_started(webmachine),
+    webmachine_util:ensure_all_started(webmachine),
     application:start(webmachine_demo).
 
 %% @spec stop() -> ok

--- a/src/webmachine.erl
+++ b/src/webmachine.erl
@@ -93,25 +93,8 @@ do_rewrite(RewriteMod, Method, Scheme, Version, Headers, RawPath) ->
 
 -include_lib("eunit/include/eunit.hrl").
 
-ensure_all_started(App, Apps0) ->
-    case application:start(App) of
-        ok ->
-            {ok, Apps0};
-        {error,{already_started,App}} ->
-            {ok, Apps0};
-        {error,{not_started,BaseApp}} ->
-            {ok, Apps} = ensure_all_started(BaseApp, Apps0),
-            ensure_all_started(App, [BaseApp|Apps])
-    end.
-
 start_mochiweb() ->
-    case erlang:function_exported(application, ensure_all_started, 1) of
-        true ->
-            {ok, Apps} = application:ensure_all_started(mochiweb),
-            {ok, lists:reverse(Apps)};
-        false ->
-            ensure_all_started(mochiweb,[])
-    end.
+    webmachine_util:ensure_all_started(mochiweb).
 
 start_stop_test() ->
     {Res, Apps} = start_mochiweb(),

--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -29,6 +29,7 @@
          quoted_string/1,
          split_quoted_strings/1]).
 -export([parse_range/2]).
+-export([ensure_all_started/1]).
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -400,6 +401,33 @@ parse_range([Spec | Rest], ResourceLength, Acc) ->
             parse_range(Rest, ResourceLength, Acc);
         {Skip, Length} ->
             parse_range(Rest, ResourceLength, [{Skip, Skip + Length - 1} | Acc])
+    end.
+
+%% On older versions of Erlang, we don't have application:ensure_all_started,
+%% so we use this wrapper function to either use the native implementation or
+%% our own version, depending on what's available.
+-spec ensure_all_started(atom()) -> {ok, [atom()]} | {error, term()}.
+ensure_all_started(App) ->
+    case erlang:function_exported(application, ensure_all_started, 1) of
+        true ->
+            application:ensure_all_started(App);
+        false ->
+            ensure_all_started(App, [])
+    end.
+
+%% Reimplementation of ensure_all_started. NOTE this does not behave the same
+%% as the native version in all cases, but as a quick hack it works well
+%% enough for our purposes. Eventually I assume we'll drop support for older
+%% versions of Erlang and this can be eliminated.
+ensure_all_started(App, Apps0) ->
+    case application:start(App) of
+        ok ->
+            {ok, lists:reverse([App | Apps0])};
+        {error,{already_started,App}} ->
+            {ok, lists:reverse(Apps0)};
+        {error,{not_started,BaseApp}} ->
+            {ok, Apps} = ensure_all_started(BaseApp, Apps0),
+            ensure_all_started(App, [BaseApp|Apps])
     end.
 
 %%


### PR DESCRIPTION
We have a special version of ensure_all_started that uses the default Erlang implementation if it's available, and otherwise falls back to our own reimplemented version of the function. I made some minor changes and factored this out into the webmachine_util module.

This function is then used in webmachine_demo to fix a startup crash that was occurring due to ssl not being started.

This PR is basically an expanded, completed version of #219 using the changes suggested by @vinoski 
