### PR TITLE
Fix #229: make sure rebar searches for templates

### DIFF
--- a/scripts/new_webmachine.sh
+++ b/scripts/new_webmachine.sh
@@ -36,4 +36,4 @@ ABSDEST=$(cd $DESTDIR && pwd)
 
 cd ${0%/*}/../priv
 
-../rebar create template=wmskel appid=$NAME prefix=$ABSDEST/$NAME
+../rebar -r create template=wmskel appid=$NAME prefix=$ABSDEST/$NAME


### PR DESCRIPTION
Commit 83b6dd7 updated rebar to a version that is no longer recursive by
default when searching for templates for its "create" subcommand. Add the
"-r" option to the rebar invocation in scripts/new_webmachine.sh to make
sure it finds its templates properly.
