### PR TITLE
Change meck deps to be "0.8.*" per @kellymclaughlin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,6 @@
  ]}.
 
 {dev_only_deps,
- [{meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
+ [{meck, "0.8.*", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
   {ibrowse, "4.0.2", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
  ]}.


### PR DESCRIPTION
When we updated the Erlang client, it inadvertently broke some dependencies.  This is the suggested fix.  Once this PR is merged, we'll need to tag it with "1.10.7" and update the Erlang client's dependency.
