### PR TITLE
Issue 240

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 # nuke deps first to avoid wasting time having rebar recurse into deps
 # for clean
 distclean:
-	@rm -rf deps ./rebar/DEV_MODE
+	@rm -rf ./deps ./.rebar
 	@(./rebar clean)
 
 edoc:
@@ -39,4 +39,5 @@ travisupload:
 	travis-artifacts upload --path ${ARTIFACTSFILE}
 
 DEV_MODE:
+	@[ -d ./.rebar ] || mkdir ./.rebar
 	@touch ./.rebar/DEV_MODE


### PR DESCRIPTION
Ensure that developer can clone and run make with success by creating `.rebar` directory if it does not already exist.

`make distclean` should completely clean your clone, so remove `.rebar`
as well.

Fixes #240 (RIAK-1380) (RIAK-1653)
