### PR TITLE
add hex metadata

### DIFF
--- a/src/webmachine.app.src
+++ b/src/webmachine.app.src
@@ -10,5 +10,11 @@
                   crypto,
                   mochiweb]},
   {mod, {webmachine_app, []}},
-  {env, []}
+  {env, []},
+
+  {contributors,["Sean Cribbs", "Joe DeVivo" "Bryan Fink",
+                 "Kelly McLaughlin", "Jared Morrow", "Andy Gross",
+                 "Steve Vinoski"]},
+  {licenses,["Apache"]},
+  {links,[{"Github","https://github.com/webmachine/webmachine"}]}
  ]}.


### PR DESCRIPTION
This so it can be published to hex.pm with proper metadata. I wasn't sure who all to put in Contributors.
