### PR TITLE
webmachine_request:get_peer/1 crashes when TCP connection is closed

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -147,6 +147,14 @@ get_sock({?MODULE, ReqState} = Req) ->
 get_sock(ReqState) ->
     get_sock({?MODULE, ReqState}).
 
+%% While this error clause will at least stop erlang from reporting
+%% "no matching clause", webmachine would need a more robust error
+%% handling case for request creation before anything more could be
+%% done with this return tuple aside from assigning it to
+%% #wm_reqstate.peer or .sock for now, which will most likely break
+%% somewhere else down the line.
+peer_from_peername({error, Error}, _Req) ->
+    {error, Error};
 peer_from_peername({ok, {Addr={10, _, _, _}, _Port}}, Req) ->
     x_peername(inet_parse:ntoa(Addr), Req);
 peer_from_peername({ok, {Addr={172, Second, _, _}, _Port}}, Req)


### PR DESCRIPTION
When webmachine starts to process a request it implicitly assumes the TCP connection is open and crashes when it's closed.

This occurred on a production Riak node when the client was closing the  connection right after sending a HTTP request (and the server was most probably under high load and reacting on the request slowly):

``` erlang
{function_clause,
    [{webmachine_request,peer_from_peername,
         [{error,enotconn},
          {webmachine_request,
              #wm_reqstate{
                  socket = #Port<0.25467643>,metadata = [],
                  range = undefined,peer = undefined,sock = undefined,
                  reqdata = 
                      #wm_reqdata{
                          method = 'GET',scheme = http,
                          version = {1,1},
                          peer = "defined_in_wm_req_srv_init",
                          sock = "defined_in_wm_req_srv_init",
                          wm_state = defined_on_call,
                          disp_path = defined_in_load_dispatch_data,path = "/ping",
                          raw_path = "/ping",path_info = [],
                          path_tokens = defined_in_load_dispatch_data,
                          app_root = "defined_in_load_dispatch_data",
                          response_code = 500,max_recv_body = 1073741824,
                          max_recv_hunk = 67108864,req_cookie = [],req_qs = [],
                          req_headers = 
                              {2,
                               {"connection",
                                {'Connection',"Close"},
                                nil,
                                {"host",{'Host',"10.0.0.1"},nil,nil}}},
                          req_body = not_fetched_yet,resp_redirect = false,
                          resp_headers = {0,nil},
                          resp_body = <<>>,resp_range = follow_request,
                          host_tokens = undefined,port = undefined,notes = []},
                  bodyfetch = undefined,reqbody = undefined,
                  log_data = undefined}}],
         [{file,"src/webmachine_request.erl"},{line,150}]},
     {webmachine_request,get_peer,1,
         [{file,"src/webmachine_request.erl"},{line,124}]},
     {webmachine,new_request,2,
         [{file,"src/webmachine.erl"},{line,59}]},
     {webmachine_mochiweb,loop,2,
         [{file,"src/webmachine_mochiweb.erl"},{line,49}]},
     {mochiweb_http,parse_headers,5,
         [{file,"src/mochiweb_http.erl"},{line,180}]},
     {proc_lib,init_p_do_apply,3,
         [{file,"proc_lib.erl"},{line,227}]}]}
```

The problem is with `webmachine_requiest:peer_from_peername/2` that has no function clause for `{error, _}` values coming from `inet:peername/1` or `ssl:peername/1`.

It is true that the client is not acting properly either (it doesn't wait for a response) but the error should be handled in a more graceful manner. For example `webmachine_request:send/2` silently ignores a closed TCP socket and calls `exit(normal)` on unforeseen errors.

So it is harmless if the client side closes the TCP socket _after_ the request is processed by the server, but a big crash report is filed if it does it _before_ the processing. This is inconsistent behaviour and generates scary error logs for harmless issues.
