### PR TITLE
If resource returns {false, ...} for is_authorized, return 401 error.

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -212,6 +212,7 @@ decision(v3b9b) ->
 decision(v3b8) ->
     case resource_call(is_authorized) of
         true -> d(v3b7);
+        false -> respond(401);
         {error, Reason} ->
             error_response(Reason);
         {halt, Code}  ->


### PR DESCRIPTION
The wiki mentions that we should return {true, RD, Ctx} on authorized
calls and {false, RD, Ctx} on calls that are not authorized. Returning
false results in 500 internal server error when wrq module tries to
set response headers. Ensure that we are checking for false along with
true and return 401 error. Otherwise, existing behavior is maintained.

Issue #254. Much thanks to @metadave for finding the issue
