### PR TITLE
Fix for enotconn errors crashing requests

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -147,6 +147,8 @@ get_sock({?MODULE, ReqState} = Req) ->
 get_sock(ReqState) ->
     get_sock({?MODULE, ReqState}).
 
+peer_from_peername({error, Error}, _Req) ->
+    {error, Error};
 peer_from_peername({ok, {Addr={10, _, _, _}, _Port}}, Req) ->
     x_peername(inet_parse:ntoa(Addr), Req);
 peer_from_peername({ok, {Addr={172, Second, _, _}, _Port}}, Req)


### PR DESCRIPTION
When clients close connections at the wrong time it can result in crashes like

```
2015-12-08 00:19:37 =CRASH REPORT====
  crasher:
    initial call: mochiweb_acceptor:init/3
    pid: <0.5880.840>
    registered_name: []
    exception error: {function_clause,[{webmachine_request,peer_from_peername,[{error,enotconn},{webmachine_request,{wm_reqstate,#Port<0.14497717>,[],undefined,undefined,undefined,{wm_reqdata,'GET',http,{1,1},"defined_in_wm_req_srv_init","defined_in_wm_req_srv_init",defined_on_call,defined_in_load_dispatch_data,...,not_fetched_yet,false,{0,nil},<<>>,follow_request,undefined,undefined,[]},undefined,undefined,undefined}}],[{file,"src/webmachine_request.erl"},{line,150}]},{webmachine_request,get_peer,1,[{file,"src/webmachine_request.erl"},{line,124}]},{webmachine,new_request,2,[{file,"src/webmachine.erl"},{line,59}]},{webmachine_mochiweb,loop,2,[{file,"src/webmachine_mochiweb.erl"},{line,49}]},{mochiweb_http,headers,5,[{file,"src/mochiweb_http.erl"},{line,96}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
    ancestors: [webmachine_mochiweb,oxgw_sup,<0.869.0>]
    messages: []
    links: [#Port<0.14497717>,<0.967.0>],..
```

This turns those into 500 errors and avoids the crashes.
