### PR TITLE
Fix mochiweb dependency so we can build with Mix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [mochiweb]}.
+{deps, [{mochiweb, "2.12.2"}]}.
 
 {eunit_opts, [
               no_tty,


### PR DESCRIPTION
This resolves errors like the below when fetching dependencies with `mix deps.get`:

```
    (mix) lib/mix/rebar.ex:201: Mix.Rebar.parse_dep({:mochiweb, nil})
```
