### PR TITLE
Fix deprecation of crypto:rand_bytes/1 in favour of crypto:strong_rand_bytes/1

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -642,7 +642,7 @@ parts_to_body(BodyList, Size, Req) when is_list(BodyList) ->
             {CT, _} ->
                 CT
         end,
-    Boundary = mochihex:to_hex(crypto:rand_bytes(8)),
+    Boundary = mochihex:to_hex(crypto:strong_rand_bytes(8)),
     HeaderList = [{"Content-Type",
                    ["multipart/byteranges; ",
                     "boundary=", Boundary]}],


### PR DESCRIPTION
OTP 19 deprecates the use of crypto:rand_bytes/1 in favour of crypto:strong_rand_bytes/1.

Since 'warnings_as_errors' flag is enabled this prevented webmachine to be compiled.
