### PR TITLE
Cleaner configuration management

### DIFF
--- a/src/webmachine.app.src
+++ b/src/webmachine.app.src
@@ -10,7 +10,18 @@
                   crypto,
                   mochiweb]},
   {mod, {webmachine_app, []}},
-  {env, []},
+  {env,
+   %% env is THE place for expected defaults. Even if it's just
+   %% comments, it's worthwhile
+   [
+    {log_handlers, []}
+   ,{error_handler, webmachine_error_handler}
+    %% error_handler is a module that implements the function render_error/3
+   ,{rewrite_module, undefined}
+    %% module that has rewrite/5
+   ,{server_name, undefined}
+    %% string() for the "Server" response header
+   ]},
 
   {contributors,["Sean Cribbs", "Joe DeVivo" "Bryan Fink",
                  "Kelly McLaughlin", "Jared Morrow", "Andy Gross",

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -121,20 +121,21 @@ new_webmachine_req(Request) ->
     Method = mochiweb_request:get(method, Request),
     Scheme = mochiweb_request:get(scheme, Request),
     Version = mochiweb_request:get(version, Request),
-    {Headers, RawPath} = case application:get_env(webmachine, rewrite_module) of
-        {ok, RewriteMod} ->
-            do_rewrite(RewriteMod,
-                       Method,
-                       Scheme,
-                       Version,
-                       mochiweb_request:get(headers, Request),
-                       mochiweb_request:get(raw_path, Request));
-        undefined ->
-            {
+    {Headers, RawPath} =
+        case application:get_env(webmachine, rewrite_module) of
+            {ok, undefined} ->
+                {
               mochiweb_request:get(headers, Request),
               mochiweb_request:get(raw_path, Request)
-         }
-    end,
+             };
+            {ok, RewriteMod} ->
+                do_rewrite(RewriteMod,
+                           Method,
+                           Scheme,
+                           Version,
+                           mochiweb_request:get(headers, Request),
+                           mochiweb_request:get(raw_path, Request))
+            end,
     Socket = mochiweb_request:get(socket, Request),
 
     InitialReqData = wrq:create(Method,Scheme,Version,RawPath,Headers),

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -100,8 +100,6 @@
 -include("wm_reqstate.hrl").
 -include("wm_reqdata.hrl").
 
--define(WMVSN, "1.10.9").
--define(QUIP, "cafe not found").
 -define(IDLE_TIMEOUT, infinity).
 
 -type t() :: {?MODULE, #wm_reqstate{}}.
@@ -744,10 +742,9 @@ make_headers(Code, Length, RD) when is_integer(Code) ->
                       mochiweb_headers:make(wrq:resp_headers(RD)))
             end
     end,
-    case application:get_env(webmachine, server_name) of
-      undefined -> ServerHeader = "MochiWeb/1.1 WebMachine/" ++ ?WMVSN ++ " (" ++ ?QUIP ++ ")";
-      {ok, ServerHeader} when is_list(ServerHeader) -> ok
-    end,
+    %% server_name is guaranteed to be set by
+    %% webmachine_app:load_default_app_config/0
+    {ok, ServerHeader} = application:get_env(webmachine, server_name),
     WithSrv = mochiweb_headers:enter("Server", ServerHeader, Hdrs0),
     Hdrs = case mochiweb_headers:get_value("date", WithSrv) of
         undefined ->


### PR DESCRIPTION
- put explicit defaults in app.src
- don't recompute Server header per request
- Pull webmachine version for Server header from application metadata

Despite the branch name, it turns out that I just did some cleanup that could lead to lager3 in the future.
