### PR TITLE
Extract initial request data from service_available in wmtrace

### DIFF
--- a/src/wmtrace_resource.erl
+++ b/src/wmtrace_resource.erl
@@ -239,10 +239,13 @@ aggregate_trace_part({result, Module, Function, Result},
      [{Decision,[{Module, Function, Args, Result}|Calls]}|Acc]};
 aggregate_trace_part({not_exported, Module, Function, Args},
                      {Q, R, [{Decision,Calls}|Acc]}) ->
-    {Q, maybe_extract_response(Function, Args, R),
+    {maybe_extract_request(Function, Args, Q),
+     maybe_extract_response(Function, Args, R),
      [{Decision,[{Module, Function, Args, wmtrace_not_exported}|Calls]}
       |Acc]}.
 
+maybe_extract_request(service_available, [ReqData, _], _) ->
+    ReqData;
 maybe_extract_request(_, _, R) ->
     R.
 


### PR DESCRIPTION
As discussed in issue webmachine/webmachine#279, commit ff44051 removed
the `ping` resource function, which wmtrace relied on to get initial
request parameters. This patch shifts `wmtrace_resource` to look for
`service_available` (the next earliest function called) instead. This
also required adding `maybe_extract_request` to the `not_exported`
branch of `aggregate_trace_part`, since not every resource exports
`service_available`, like they did `ping`.