### PR TITLE
Eliminate use of module_info to check whether a module exports a function

### DIFF
--- a/include/wm_resource.hrl
+++ b/include/wm_resource.hrl
@@ -1,1 +1,1 @@
--record(wm_resource, {module, modstate, modexports, trace}).
+-record(wm_resource, {module, modstate, trace}).

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -17,7 +17,7 @@
 -module(webmachine_resource).
 -author('Justin Sheehy <justin@basho.com>').
 -author('Andy Gross <andy@basho.com>').
--export([new/4, wrap/2]).
+-export([new/3, wrap/2]).
 -export([do/3,log_d/2,stop/1]).
 
 -include("wm_resource.hrl").
@@ -27,11 +27,16 @@
 -type t() :: #wm_resource{}.
 -export_type([t/0]).
 
-new(R_Mod, R_ModState, R_ModExports, R_Trace) ->
+-define(CALLBACK_ARITY, 2).
+
+new(R_Mod, R_ModState, R_Trace) ->
+    case erlang:module_loaded(R_Mod) of
+        false -> code:ensure_loaded(R_Mod);
+        true -> ok
+    end,
     #wm_resource{
        module = R_Mod,
        modstate = R_ModState,
-       modexports = R_ModExports,
        trace = R_Trace
       }.
 
@@ -118,15 +123,13 @@ default(_) ->
 wrap(Mod, Args) ->
     case Mod:init(Args) of
         {ok, ModState} ->
-            {ok, webmachine_resource:new(Mod, ModState,
-                           orddict:from_list(Mod:module_info(exports)), false)};
+            {ok, webmachine_resource:new(Mod, ModState, false)};
         {{trace, Dir}, ModState} ->
             {ok, File} = open_log_file(Dir, Mod),
             log_decision(File, v3b14),
             log_call(File, attempt, Mod, init, Args),
             log_call(File, result, Mod, init, {{trace, Dir}, ModState}),
-            {ok, webmachine_resource:new(Mod, ModState,
-                orddict:from_list(Mod:module_info(exports)), File)};
+            {ok, webmachine_resource:new(Mod, ModState, File)};
         _ ->
             {stop, bad_init_arg}
     end.
@@ -136,7 +139,6 @@ do(#wm_resource{}=Res, Fun, ReqProps) ->
 do(Fun, ReqProps,
    #wm_resource{
       module=R_Mod,
-      modexports=R_ModExports,
       trace=R_Trace
      }=Req)
   when is_atom(Fun) andalso is_list(ReqProps) ->
@@ -155,21 +157,20 @@ do(Fun, ReqProps,
     %% Do not need the embedded state anymore
     TrimData = ReqData#wm_reqdata{wm_state=undefined},
     {Reply,
-     webmachine_resource:new(R_Mod, NewModState, R_ModExports, R_Trace),
+     webmachine_resource:new(R_Mod, NewModState, R_Trace),
      ReqState#wm_reqstate{reqdata=TrimData}}.
 
 handle_wm_call(Fun, ReqData,
                #wm_resource{
                   module=R_Mod,
                   modstate=R_ModState,
-                  modexports=R_ModExports,
                   trace=R_Trace
                  }=Req) ->
     case default(Fun) of
         no_default ->
             resource_call(Fun, ReqData, Req);
         Default ->
-            case orddict:is_key(Fun, R_ModExports) of
+            case erlang:function_exported(R_Mod, Fun, ?CALLBACK_ARITY) of
                 true ->
                     resource_call(Fun, ReqData, Req);
                 false ->
@@ -200,12 +201,13 @@ resource_call(F, ReqData,
         _ -> log_call(R_Trace, attempt, R_Mod, F, [ReqData, R_ModState])
     end,
     Result = try
+        %% Note: the argument list must match the definition of CALLBACK_ARITY
         apply(R_Mod, F, [ReqData, R_ModState])
     catch C:R ->
             Reason = {C, R, trim_trace(erlang:get_stacktrace())},
             {{error, Reason}, ReqData, R_ModState}
     end,
-        case R_Trace of
+    case R_Trace of
         false -> nop;
         _ -> log_call(R_Trace, result, R_Mod, F, Result)
     end,


### PR DESCRIPTION
Calling module_info() is comparatively expensive and is best avoided. 