### PR TITLE
Make webmachine_mochiweb loop call use latest version of module

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -63,7 +63,7 @@ start(Options) ->
     webmachine_router:init_routes(DGroup, DispatchList),
     _ = [application_set_unless_env_or_undef(K, V) || {K, V} <- WMOptions],
     MochiName = list_to_atom(to_list(PName) ++ "_mochiweb"),
-    LoopFun = fun(X) -> loop(DGroup, X) end,
+    LoopFun = fun(X) -> ?MODULE:loop(DGroup, X) end,
     mochiweb_http:start([{name, MochiName}, {loop, LoopFun} | OtherOptions]).
 
 stop() ->


### PR DESCRIPTION
This makes the code a bit more resilient to live upgrades between versions in case internal api:s change.