### PR TITLE
Upgrade mochiweb dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: erlang
 sudo: false
 install: "true" # don't let travis run get-deps
 otp_release:
+  - 20.0
   - 19.1
   - 18.3
   - 17.5

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, "2.12.2"}]}.
+{deps, [{mochiweb, {git, "https://github.com/mochi/mochiweb", {tag, "v2.17.0"}}}]}.
 
 {eunit_opts, [
               no_tty,
@@ -15,7 +15,7 @@
 {profiles,
  [{test,
    [{deps, [meck,
-            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
+            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.4.0"}}},
             {eunit_formatters, {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
            ]},
     {erl_opts, [debug_info]}

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 {profiles,
  [{test,
    [{deps, [meck,
-            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.4.0"}}},
+            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
             {eunit_formatters, {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
            ]},
     {erl_opts, [debug_info]}

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 {profiles,
  [{test,
    [{deps, [meck,
-            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}},
+            {ibrowse, {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.4.0"}}},
             {eunit_formatters, {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
            ]},
     {erl_opts, [debug_info]}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,4 @@
-{"1.1.0",
-[{<<"mochiweb">>,{pkg,<<"mochiweb">>,<<"2.12.2">>},0}]}.
-[
-{pkg_hash,[
- {<<"mochiweb">>, <<"80804AD342AFA3D7F3524040D4EED66CE74B17A555DE454AC85B07C479928E46">>}]}
-].
+[{<<"mochiweb">>,
+  {git,"https://github.com/mochi/mochiweb",
+       {ref,"23dc11959affd9b0849c2ac0ff4200c1c82aa80c"}},
+  0}].

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -20,7 +20,16 @@
 -include("wm_reqdata.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile(export_all).
+-export([size_stream_raises_error/2, process_post_for_created_p11/3, get_streamed_body/2, send_streamed_body/2,
+         accept_text/2, writer_response/2, known_length_body/2, range_response/2, stream_content_md5/0,
+         validate_checksum_for_md5stream/3, process_post_for_md5_stream/3, init/1, service_available/2,
+         validate_content_checksum/2, is_authorized/2, allowed_methods/2, known_methods/2, uri_too_long/2,
+         known_content_type/2, valid_entity_length/2, malformed_request/2, forbidden/2, valid_content_headers/2,
+         content_types_provided/2, content_types_accepted/2, language_available/2, charsets_provided/2,
+         encodings_provided/2, resource_exists/2, generate_etag/2, last_modified/2, moved_permanently/2,
+         moved_temporarily/2, previously_existed/2, allow_missing_post/2, post_is_create/2, process_post/2,
+         create_path/2, is_conflict/2, multiple_choices/2, base_uri/2, base_uri_add_slash/1, expires/2,
+         delete_resource/2, delete_completed/2, to_html/2]).
 
 -define(RESOURCE, atom_to_list(?MODULE)).
 -define(RESOURCE_PATH, "/" ++ ?RESOURCE).

--- a/test/wm_integration_test.erl
+++ b/test/wm_integration_test.erl
@@ -17,8 +17,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("webmachine.hrl").
 
--compile([export_all]).
-
 integration_test_() ->
     {foreach,
      %% Setup


### PR DESCRIPTION
Fixes #291.

- To enable compatibility with Erlang 20, **mochiweb** was upgraded to **v2.17.0**.
- The **ibrowse** dependency was upgraded to **v4.4.0** to remove the `erlang:now/0` warning.
- Two `-compile(export_all).` statements were removed. One was replaced with an appropriate `-export([...]).` statement.