### PR TITLE
Suppress stacktrace-related warnings in OTP21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: erlang
 sudo: false
 install: "true" # don't let travis run get-deps
 otp_release:
+  - 21.0
   - 20.0
   - 19.1
   - 18.3

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -24,6 +24,12 @@
 -export([handle_request/2]).
 -include("webmachine_logger.hrl").
 
+%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
+%% stacktraces.
+-ifdef(OTP_RELEASE).
+-compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
+-endif.
+
 handle_request(Resource, ReqState) ->
     _ = [erase(X) || X <- [decision, code, req_body, bytes_written, tmp_reqstate]],
     put(resource, Resource),

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -29,6 +29,12 @@
 
 -define(CALLBACK_ARITY, 2).
 
+%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
+%% stacktraces.
+-ifdef(OTP_RELEASE).
+-compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
+-endif.
+
 new(R_Mod, R_ModState, R_Trace) ->
     case erlang:module_loaded(R_Mod) of
         false -> code:ensure_loaded(R_Mod);

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -44,6 +44,12 @@ md5(Bin) ->
     crypto:md5(Bin).
 -endif.
 
+%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
+%% stacktraces.
+-ifdef(OTP_RELEASE).
+-compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
+-endif.
+
 -define(HTTP_1_0_METHODS, ['GET', 'POST', 'HEAD']).
 -define(HTTP_1_1_METHODS, ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE',
                            'CONNECT', 'OPTIONS']).


### PR DESCRIPTION
In Erlang/OTP 21 warnings are thrown for using `erlang:get_stacktrace()`, which can cause builds to fail. This PR suppresses those warnings until a decision about upgrading to the new stacktrace syntax is made.

This fixes #293.