### PR TITLE
OTP 21 compatibility

### DIFF
--- a/include/wm_compat.hrl
+++ b/include/wm_compat.hrl
@@ -1,0 +1,7 @@
+-ifndef(deprecate_stacktrace).
+-define(STPATTERN(Pattern), Pattern).
+-define(STACKTRACE, erlang:get_stacktrace()).
+-else.
+-define(STPATTERN(Pattern), Pattern:__STACKTRACE).
+-define(STACKTRACE, __STACKTRACE).
+-endif.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -11,4 +11,15 @@ Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion < "R15B02" of
                           CONFIG ++ [{erl_opts, HashDefine}]
                   end;
               false -> CONFIG
-          end.
+          end,
+if
+    OtpVersion >= "21" ->
+        case lists:keysearch(erl_opts, 1, Config1) of
+            {value, {erl_opts, Opts2}} ->
+                lists:keyreplace(erl_opts, 1, Config1, {erl_opts, [{d, deprecate_stacktrace}|Opts2]});
+            false ->
+                [{erl_opts, [{d, deprecate_stacktrace}]}|Config1]
+        end;
+    true ->
+        Config1
+end.

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -23,6 +23,7 @@
 -author('Bryan Fink <bryan@basho.com>').
 -export([handle_request/2]).
 -include("webmachine_logger.hrl").
+-include("wm_compat.hrl").
 
 %% Suppress Erlang/OTP 21 warnings about the new method to retrieve
 %% stacktraces.
@@ -37,8 +38,8 @@ handle_request(Resource, ReqState) ->
     try
         d(v3b13)
     catch
-        error:_ ->
-            error_response(erlang:get_stacktrace())
+        ?STPATTERN(error:_Reason) ->
+            error_response(?STACKTRACE)
     end.
 
 wrcall(X) ->

--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -628,7 +628,7 @@ make_reqdata(Path) ->
     MochiReq = mochiweb_request:new(testing, 'GET', Path, {1, 1},
                                     mochiweb_headers:make([])),
     Req = webmachine:new_request(mochiweb, MochiReq),
-    {RD, _} = Req:get_reqdata(),
+    {RD, _} = webmachine_request:get_reqdata(Req),
     RD.
 
 -endif.

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -20,6 +20,7 @@
 -export([new/3, wrap/2]).
 -export([do/3,log_d/2,stop/1]).
 
+-include("wm_compat.hrl").
 -include("wm_resource.hrl").
 -include("wm_reqdata.hrl").
 -include("wm_reqstate.hrl").
@@ -209,8 +210,8 @@ resource_call(F, ReqData,
     Result = try
         %% Note: the argument list must match the definition of CALLBACK_ARITY
         apply(R_Mod, F, [ReqData, R_ModState])
-    catch C:R ->
-            Reason = {C, R, trim_trace(erlang:get_stacktrace())},
+    catch ?STPATTERN(C:R) ->
+            Reason = {C, R, trim_trace(?STACKTRACE)},
             {{error, Reason}, ReqData, R_ModState}
     end,
     case R_Trace of

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -17,6 +17,7 @@
 
 -ifdef(TEST).
 
+-include("wm_compat.hrl").
 -include("wm_reqdata.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -335,8 +336,8 @@ setup() ->
         meck:new(webmachine_resource, MeckOpts),
         Ctx
     catch
-        T:E ->
-            io:format(user, "~n~p : ~p : ~p", [T, E, erlang:get_stacktrace()]),
+        ?STPATTERN(T:E) ->
+            io:format(user, "~n~p : ~p : ~p", [T, E, ?STACKTRACE]),
             error(setup_failed)
     end.
 


### PR DESCRIPTION
* Deal with stacktrace patterns in a backwards-compatible way
* Handle a place where were still using tuple-mods on module position, causing `badarg`