### PR TITLE
OTP 21.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ ebin
 doc/*
 .local_dialyzer_plt
 /.rebar
+/.rebar3
 _build
 .DS_Store

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -31,9 +31,9 @@ handle_request(Resource, ReqState) ->
     put(reqstate, ReqState),
     try
         d(v3b13)
-    catch
-        error:_ ->
-            error_response(erlang:get_stacktrace())
+    catch 
+        error:_:Stacktrace ->
+            error_response(Stacktrace)
     end.
 
 wrcall(X) ->

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -648,7 +648,7 @@ parts_to_body(BodyList, Size, Req) when is_list(BodyList) ->
             {CT, _} ->
                 CT
         end,
-    Boundary = mochihex:to_hex(crypto:rand_bytes(8)),
+    Boundary = mochihex:to_hex(crypto:strong_rand_bytes(8)),
     HeaderList = [{"Content-Type",
                    ["multipart/byteranges; ",
                     "boundary=", Boundary]}],

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -184,8 +184,10 @@ resource_call(F, ReqData, {?MODULE, R_Mod, R_ModState, _, R_Trace}) ->
     end,
     Result = try
         apply(R_Mod, F, [ReqData, R_ModState])
-    catch C:R ->
-            Reason = {C, R, trim_trace(erlang:get_stacktrace())},
+    catch C:R:Stacktrace ->
+        %% _build/default/lib/webmachine/src/webmachine_resource.erl:188: 
+        %% erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
+            Reason = {C, R, trim_trace(Stacktrace)},
             {{error, Reason}, ReqData, R_ModState}
     end,
         case R_Trace of


### PR DESCRIPTION
Creating skeleton project fails using instructions at https://github.com/Webmachine/webmachine when building the project if using the erlang 21.2 build from erlang solutions (https://www.erlang-solutions.com/resources/download.html).  Appear to be 2 errors:

* use of erlang:get_stacktrace/0 which has now been deprecated;
* use of crypto:strong_rand_bytes/0 has replaced crypto:rand_bytes/0

PR rectifies both of these, though doesn't make any provision for building correctly on previous OTP releases.  

Note: I'm an erlang novice so please treat with appropriate caution.