### PR TITLE
Update mochiweb dependency to git

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, "2.18.0"}]}.
+{deps, [{mochiweb, {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.20.0"}}}]}.
 
 {eunit_opts, [
               no_tty,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,4 @@
-{"1.1.0",
-[{<<"mochiweb">>,{pkg,<<"mochiweb">>,<<"2.18.0">>},0}]}.
-[
-{pkg_hash,[
- {<<"mochiweb">>, <<"EB55F1DB3E6E960FAC4E6DB4E2DB9EC3602CC9F30B86CD1481D56545C3145D2E">>}]}
-].
+[{<<"mochiweb">>,
+  {git,"git://github.com/mochi/mochiweb.git",
+       {ref,"cedc22f66a8e3f3885fb06babc0c0582418508f8"}},
+  0}].


### PR DESCRIPTION
The latest version of mochiweb can't be found in hex and the current
project owner does not have control to publish a new version. In order
to have webmachine be more compatible with erlang 21, the mochiweb version
needs to be upgraded as the "tuple calls" have officially been removed
from the language.