### PR TITLE
Fix mochiweb include for rebar2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.20.0"}}}]}.
+{deps, [{mochiweb, "2.20.0", {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.20.0"}}}]}.
 
 {eunit_opts, [
               no_tty,


### PR DESCRIPTION
rebar2 doesn't like the include style for rebar3, not surprising,
so changing it to a legacy format makes rebar2 and rebar3 happy.