### PR TITLE
Upgrade mochiweb to latest version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.20.0"}}}]}.
+{deps, [{mochiweb, "2.22.0", {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.22.0"}}}]}.
 
 {eunit_opts, [
               no_tty,


### PR DESCRIPTION
The newest version of mochiweb has fixes in it to work with erlang 23+.
Upgrading the to the latest version will make webmachine more
compatible as well.