### PR TITLE
return default peer on empty x-forwarded-for

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -167,7 +167,14 @@ x_peername(Default, Req) ->
     {undefined, _} ->
         Default;
     {Hosts, _} ->
-        string:strip(lists:last(string:tokens(Hosts, ",")))
+        case string:tokens(Hosts, ",") of
+            [] ->
+                %% both Hosts="" and Hosts=",,," cause this, so check
+                %% here instead of before tokenization
+                Default;
+            HostList ->
+                string:strip(lists:last(HostList))
+        end
     end.
 
 call(base_uri, {?MODULE, ReqState}) ->


### PR DESCRIPTION
As reported in #174, an empty X-Forwarded-For header would cause a crash in `x_peername` at the call to `lists:last/1`. This change checks whether the header is empty, and returns the `Default` value if so to avoid this crash.

The check is made after the tokenization, because otherwise a header value of ",,,,," would also produce an empty list for lists:last to crash on.