### PR TITLE
prevent access logger from barfing on missing end time

### DIFF
--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -138,8 +138,17 @@ format_req(#wm_log_data{method=Method,
         end,
     case RequestTiming of
         true ->
+            % EndTime will be undefined in some error conditions,
+            % including if the request did not match any dispatch rule
+            RealEndTime = case EndTime of
+                              undefined ->
+                                  os:timestamp();
+                              _ ->
+                                  EndTime
+                          end,
             fmt_alog(Time, Peer, User, Method, Path, Version,
-                     Status, Length, Referer, UserAgent, timer:now_diff(EndTime, StartTime));
+                     Status, Length, Referer, UserAgent,
+                     timer:now_diff(RealEndTime, StartTime));
         false ->
             fmt_alog(Time, Peer, User, Method, Path, Version,
                      Status, Length, Referer, UserAgent)


### PR DESCRIPTION
In some error cases, like when a request does not match any dispatch rule, no `end_time` is set in the requests's log data. If `RequestTiming` was enabled in `webmachine_access_log_handler`, this would pass `undefined` to `timer:now_diff/2`, causing the process to exit with reason `function_clause`.

This patch substitutes the current time for a missing end time to prevent the exit from happening.

Found while researching #172, but only half related (does not fix that issue).

The alternate fix here would have been to use `webmachine_util:now_diff_milliseconds/2`, but I thought it better to keep the unit as microseconds, so as not to surprise anyone upgrading.