### PR TITLE
use monotonic time to measure request timing

### DIFF
--- a/include/webmachine_logger.hrl
+++ b/include/webmachine_logger.hrl
@@ -2,7 +2,7 @@
 %% see erlang:decode_packet documentation
 -record(wm_log_data,
         {resource_module :: atom(),
-         start_time :: tuple(),
+         start_time :: integer(), % erlang monotonic time, native units
          method :: atom() | string() | binary(),
 
          headers,
@@ -12,8 +12,8 @@
          version,
          response_code,
          response_length,
-         end_time :: undefined | tuple(),
-         finish_time :: undefined | tuple(),
+         end_time :: undefined | integer(), % monotonic time, native units
+         finish_time :: undefined | integer(), % monotonic time, native units
          notes}).
 -type wm_log_data() :: #wm_log_data{}.
 

--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -111,9 +111,7 @@ format_req(#wm_log_data{method=Method,
                         path=Path,
                         version=Version,
                         response_code=ResponseCode,
-                        response_length=ResponseLength,
-                        start_time=StartTime,
-                        end_time=EndTime},
+                        response_length=ResponseLength}=LogData,
           RequestTiming) ->
     User = "-",
     Time = webmachine_log:fmtnow(),
@@ -138,17 +136,12 @@ format_req(#wm_log_data{method=Method,
         end,
     case RequestTiming of
         true ->
-            % EndTime will be undefined in some error conditions,
-            % including if the request did not match any dispatch rule
-            RealEndTime = case EndTime of
-                              undefined ->
-                                  os:timestamp();
-                              _ ->
-                                  EndTime
-                          end,
+            Timing = erlang:convert_time_unit(
+                       webmachine_log:request_processing_time(LogData),
+                       native,
+                       microsecond),
             fmt_alog(Time, Peer, User, Method, Path, Version,
-                     Status, Length, Referer, UserAgent,
-                     timer:now_diff(RealEndTime, StartTime));
+                     Status, Length, Referer, UserAgent, Timing);
         false ->
             fmt_alog(Time, Peer, User, Method, Path, Version,
                      Status, Length, Referer, UserAgent)

--- a/src/webmachine_access_log_handler.erl
+++ b/src/webmachine_access_log_handler.erl
@@ -139,7 +139,7 @@ format_req(#wm_log_data{method=Method,
             Timing = erlang:convert_time_unit(
                        webmachine_log:request_processing_time(LogData),
                        native,
-                       microsecond),
+                       micro_seconds),
             fmt_alog(Time, Peer, User, Method, Path, Version,
                      Status, Length, Referer, UserAgent, Timing);
         false ->

--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -69,7 +69,7 @@ respond(Code) when is_integer(Code) ->
     respond({Code, undefined});
 respond({_, _}=CodeAndPhrase) ->
     Resource = get(resource),
-    EndTime = os:timestamp(),
+    EndTime = erlang:monotonic_time(),
     respond(CodeAndPhrase, Resource, EndTime).
 
 respond({Code, _ReasonPhrase}=CodeAndPhrase, Resource, EndTime)
@@ -110,7 +110,7 @@ error_response(Reason) ->
 
 error_response(Code, Reason) ->
     Resource = get(resource),
-    EndTime = os:timestamp(),
+    EndTime = erlang:monotonic_time(),
     error_response({Code, undefined}, Reason, Resource, EndTime).
 
 error_response({Code, _}=CodeAndPhrase, Resource, EndTime) ->

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -137,7 +137,7 @@ new_webmachine_req(Request) ->
     Socket = mochiweb_request:get(socket, Request),
 
     InitialReqData = wrq:create(Method,Scheme,Version,RawPath,Headers),
-    InitialLogData = #wm_log_data{start_time=os:timestamp(),
+    InitialLogData = #wm_log_data{start_time=erlang:monotonic_time(),
                                   method=Method,
                                   headers=Headers,
                                   path=RawPath,

--- a/src/webmachine_perf_log_handler.erl
+++ b/src/webmachine_perf_log_handler.erl
@@ -112,11 +112,11 @@ format_req(#wm_log_data{resource_module=Mod,
     TTPD = erlang:convert_time_unit(
              webmachine_log:request_processing_time(LogData),
              native,
-             millisecond),
+             milli_seconds),
     TTPS = erlang:convert_time_unit(
              webmachine_log:post_processing_time(LogData),
              native,
-             millisecond),
+             milli_seconds),
     fmt_plog(Time, Peer, Method, Path, Version,
              Status, Length, atom_to_list(Mod), integer_to_list(TTPD),
              integer_to_list(TTPS)).

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -282,7 +282,7 @@ call({send_response, {Code, ReasonPhrase}=CodeAndReason}, Req)
                 send_response(CodeAndReason, Req)
         end,
     LogData = NewState#wm_reqstate.log_data,
-    NewLogData = LogData#wm_log_data{finish_time=os:timestamp()},
+    NewLogData = LogData#wm_log_data{finish_time=erlang:monotonic_time()},
     {Reply, NewState#wm_reqstate{log_data=NewLogData}};
 call(resp_body, {?MODULE, ReqState}) ->
     {wrq:resp_body(ReqState#wm_reqstate.reqdata), ReqState};


### PR DESCRIPTION
Issue #172 noted that occasionally the perf logger would log a negative request duration. This must be due to the OS time changing (for example, because NTP is adjusting it).

Erlang docs now suggest [using `erlang:monotonic_time/0` to measure elapsed time](https://www.erlang.org/doc/apps/erts/time_correction.html#how-to-work-with-the-new-api), instead of the os:timestamp/0 we had been using, to avoid this situation, which they refer to as "time warps".

This change switches all uses of `#wm_log_data.start_time`, `.end_time`, and `.finish_time` to monotonic time.

Applications that upgrade to a version of webmachine containing this patch should also first make sure their code is [time warp safe](https://www.erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Safe_Code), and then enable [multi-time warp
mode](https://www.erlang.org/doc/apps/erts/time_correction.html#multi-time-warp-mode) by adding `+C multi_time_warp` to their VM args. They should also make sure that they are *not* passing `+c false` to disable time correction. Without `+C multi_time_warp` or with `+c false`, request durations may be logged as either zero or much longer than reality in the event that system time moves backward or forward. This is not a regression, only a heads up that things can be better.