### PR TITLE
ignore case of expect header

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -475,12 +475,17 @@ read_whole_stream({Hunk,Next}, Acc0, MaxRecvBody, SizeAcc) ->
 recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
     put(mochiweb_request_recv, true),
     case get_header_value("expect", PassedState) of
-        {"100-continue", _} ->
-            send(PassedState#wm_reqstate.socket,
-                 [make_version(wrq:version(RD)),
-                  make_code(100), <<"\r\n\r\n">>]);
-        _Else ->
-            ok
+        {undefined, _} ->
+            ok;
+        {Continue, _} ->
+            case string:equal(Continue, "100-continue", true) of
+                true ->
+                    send(PassedState#wm_reqstate.socket,
+                         [make_version(wrq:version(RD)),
+                          make_code(100), <<"\r\n\r\n">>]);
+                false ->
+                    ok
+            end
     end,
     case body_length(PassedState) of
         {unknown_transfer_encoding, X} -> exit({unknown_transfer_encoding, X});

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -478,12 +478,12 @@ recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
         {undefined, _} ->
             ok;
         {Continue, _} ->
-            case string:equal(Continue, "100-continue", true) of
-                true ->
+            case string:to_lower(Continue) of
+                "100-continue" ->
                     send(PassedState#wm_reqstate.socket,
                          [make_version(wrq:version(RD)),
                           make_code(100), <<"\r\n\r\n">>]);
-                false ->
+                _ ->
                     ok
             end
     end,


### PR DESCRIPTION
100-continue, 100-Continue, 100-CONTINUE etc. are all valid ways to specify the Expect header (see issue #235 and
https://www.rfc-editor.org/rfc/rfc7231#section-5.1.1 )