### PR TITLE
upgrade mochiweb dep to v3.1.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, "2.22.0", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.22.0"}}}]}.
+{deps, [{mochiweb, "3.1.1", {git, "https://github.com/mochi/mochiweb.git", {tag, "v3.1.1"}}}]}.
 
 {eunit_opts, [
               no_tty,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb.git",
-       {ref,"cedc22f66a8e3f3885fb06babc0c0582418508f8"}},
+       {ref,"7c4d3110b1889a5d58eb4dda2b1ddbb5645df3e9"}},
   0}].


### PR DESCRIPTION
I don't know that this solves any actual problems for us, but it doesn't seem to break anything, and it cleans up a handful of build warnings on OTP 23-25.

[Build on OTP23 before this change](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357):

```
===> Compiling mochiweb
[12](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:13)
_build/default/lib/mochiweb/src/mochiweb_session.erl:145: Warning: crypto:block_encrypt/4 is deprecated and will be removed in OTP 24; use use crypto:crypto_one_time/5, crypto:crypto_one_time_aead/6,7 or crypto:crypto_(dyn_iv)?_init + crypto:crypto_(dyn_iv)?_update + crypto:crypto_final instead
[13](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:14)
_build/default/lib/mochiweb/src/mochiweb_session.erl:150: Warning: crypto:block_decrypt/4 is deprecated and will be removed in OTP 24; use use crypto:crypto_one_time/5, crypto:crypto_one_time_aead/6,7 or crypto:crypto_(dyn_iv)?_init + crypto:crypto_(dyn_iv)?_update + crypto:crypto_final instead
[14](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:15)
_build/default/lib/mochiweb/src/mochiweb_session.erl:154: Warning: crypto:hmac/3 is deprecated and will be removed in OTP 24; use use crypto:mac/4 instead
[15](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:16)
_build/default/lib/mochiweb/src/mochiweb_session.erl:158: Warning: crypto:hmac/3 is deprecated and will be removed in OTP 24; use use crypto:mac/4 instead
[16](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:17)

[17](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:18)
_build/default/lib/mochiweb/src/mochiweb_socket.erl:33: Warning: ssl:cipher_suites/0 is deprecated and will be removed in OTP 24; use use cipher_suites/2,3 instead
[18](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:19)

[19](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:20)
===> Analyzing applications...
[20](https://github.com/webmachine/webmachine/actions/runs/4077462059/jobs/7026511357#step:4:21)
```

[Build on OTP23 after this change](https://github.com/beerriot/webmachine/actions/runs/4077795169/jobs/7027245419):

```
===> Compiling mochiweb
[12](https://github.com/beerriot/webmachine/actions/runs/4077795169/jobs/7027245419#step:4:13)
===> Analyzing applications...
[13](https://github.com/beerriot/webmachine/actions/runs/4077795169/jobs/7027245419#step:4:14)
```
