### PR TITLE
Remove parameterized module syntax from error logger

### DIFF
--- a/src/webmachine_error_log_handler.erl
+++ b/src/webmachine_error_log_handler.erl
@@ -119,15 +119,27 @@ format_req(info, undefined, _, Msg) ->
 format_req(error, undefined, _, Msg) ->
     ["[error] ", Msg];
 format_req(error, 501, Req, _) ->
-    {Path, _} = Req:path(),
-    {Method, _} = Req:method(),
+    {Path, _} = webmachine_request:path(Req),
+    {Method, _} = webmachine_request:method(Req),
     Reason = "Webmachine does not support method ",
     ["[error] ", Reason, Method, ": path=", Path, $\n];
 format_req(error, 503, Req, _) ->
-    {Path, _} = Req:path(),
+    {Path, _} = webmachine_request:path(Req),
     Reason = "Webmachine cannot fulfill the request at this time",
     ["[error] ", Reason, ": path=", Path, $\n];
 format_req(error, _Code, Req, Reason) ->
-    {Path, _} = Req:path(),
+    {Path, _} = webmachine_request:path(Req),
     Str = io_lib:format("~p", [Reason]),
     ["[error] path=", Path, $\x20, Str, $\n].
+
+-ifdef(TEST).
+
+-include("wm_reqstate.hrl").
+
+format_req_test() ->
+    Headers = webmachine_headers:empty(),
+    Wrq = wrq:create('GET', {1,1}, "/test/path", Headers),
+    Req = #wm_reqstate{reqdata=Wrq},
+    ?assertMatch("[error] path=/test/path {error,test}\n",
+                 lists:flatten(format_req(error, 500, Req, {error, test}))).
+-endif.

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -15,11 +15,15 @@
 %%    See the License for the specific language governing permissions and
 %%    limitations under the License.
 
-%% @doc Webmachine HTTP Request Abstraction. The functions in this module
-%% can be invoked using either parameterized module syntax or regular
-%% invocation syntax. Since the Ericsson OTP team is removing the
-%% parameterized module syntax in version R16, we encourage you to write
-%% your applications using regular function syntax.
+%% @doc Webmachine HTTP Request Abstraction.
+%%
+%% If you are using OTP20 or earlier, the functions in this module can
+%% be invoked using either parameterized module syntax or regular
+%% invocation syntax. Parameterized module syntax has been removed in
+%% OTP21 and later. The parameterized module framework has been left
+%% in place here while we continue to support earlier OTP versions,
+%% but we encourage you to write your applications using regular
+%% function syntax, to prepare for future upgrades.
 %%
 %% To use parameterized module syntax, you create an instance and then
 %% invoke functions on that instance, like this:


### PR DESCRIPTION
The `webmachine_error_log_handler` module still used parameterized module syntax, even though that was removed in OTP 21. No tests checked that it worked, so it has just been broken on recent OTP versions.

This change adds a test that passed on OTP =< 20 and failed on OTP >= 21 without the other code modifications. ([See differences in failures here](https://github.com/beerriot/webmachine/actions/runs/4117591432).) It also updated the parameterized module explanation at the top of webmachine_request to more strongly discourage its use.