### PR TITLE
drop support for OTP 18/19

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,12 +22,6 @@ jobs:
           - otp_version: 20
             rebar3_version: "3.15"
             os: "ubuntu-20.04"
-          - otp_version: 19
-            rebar3_version: "3.15"
-            os: "ubuntu-18.04"
-          - otp_version: 18
-            rebar3_version: "3.13"
-            os: "ubuntu-18.04"
       fail-fast: false
       max-parallel: 2
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,25 +1,14 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 OtpVersion = erlang:system_info(otp_release),
-Config1 = case hd(OtpVersion) =:= $R andalso OtpVersion < "R15B02" of
-              true  ->
-                  HashDefine = [{d,old_hash}],
-                  case lists:keysearch(erl_opts, 1, CONFIG) of
-                      {value, {erl_opts, Opts}} ->
-                          lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
-                      false ->
-                          CONFIG ++ [{erl_opts, HashDefine}]
-                  end;
-              false -> CONFIG
-          end,
 if
     OtpVersion >= "21" ->
-        case lists:keysearch(erl_opts, 1, Config1) of
+        case lists:keysearch(erl_opts, 1, CONFIG) of
             {value, {erl_opts, Opts2}} ->
-                lists:keyreplace(erl_opts, 1, Config1, {erl_opts, [{d, deprecate_stacktrace}|Opts2]});
+                lists:keyreplace(erl_opts, 1, CONFIG, {erl_opts, [{d, deprecate_stacktrace}|Opts2]});
             false ->
-                [{erl_opts, [{d, deprecate_stacktrace}]}|Config1]
+                [{erl_opts, [{d, deprecate_stacktrace}]}|CONFIG]
         end;
     true ->
-        Config1
+        CONFIG
 end.


### PR DESCRIPTION
Github is deprecating actions support for Ubuntu 18.04. See the build/test run on #234 and https://github.com/actions/runner-images/issues/6002

OTP 18 and 19 have been the cause of a few fixup commits in recent changes anyway, because of missing functions. Time to get rid of them.

This also removes a long unneeded bit of rebar config related to R15.