### PR TITLE
Small error stacktrace improvements

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -25,12 +25,6 @@
 -include("webmachine_logger.hrl").
 -include("wm_compat.hrl").
 
-%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
-%% stacktraces.
--ifdef(OTP_RELEASE).
--compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
--endif.
-
 handle_request(Resource, ReqState) ->
     _ = [erase(X) || X <- [decision, code, req_body, bytes_written, tmp_reqstate]],
     put(resource, Resource),

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -23,6 +23,7 @@
 -include("webmachine_logger.hrl").
 -include("wm_reqstate.hrl").
 -include("wm_reqdata.hrl").
+-include("wm_compat.hrl").
 
 -type mochiweb_request() ::
         {
@@ -103,12 +104,12 @@ loop(MochiReq, Name) ->
                                   XReq1),
                     webmachine_decision_core:handle_request(Resource, RS2)
                 catch
-                    error:Error ->
-                        handle_error(500, {error, Error}, Req)
+                    ?STPATTERN(error:Error) ->
+                        handle_error(500, {error, Error, ?STACKTRACE}, Req)
                 end
         catch
-            Type : Error ->
-                handle_error(500, {Type, Error}, Req)
+            ?STPATTERN(Type : Error) ->
+                handle_error(500, {Type, Error, ?STACKTRACE}, Req)
         end
     end.
 

--- a/src/webmachine_resource.erl
+++ b/src/webmachine_resource.erl
@@ -30,12 +30,6 @@
 
 -define(CALLBACK_ARITY, 2).
 
-%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
-%% stacktraces.
--ifdef(OTP_RELEASE).
--compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
--endif.
-
 new(R_Mod, R_ModState, R_Trace) ->
     case erlang:module_loaded(R_Mod) of
         false -> code:ensure_loaded(R_Mod);

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -45,12 +45,6 @@ md5(Bin) ->
     crypto:md5(Bin).
 -endif.
 
-%% Suppress Erlang/OTP 21 warnings about the new method to retrieve
-%% stacktraces.
--ifdef(OTP_RELEASE).
--compile({nowarn_deprecated_function, [{erlang, get_stacktrace, 0}]}).
--endif.
-
 -define(HTTP_1_0_METHODS, ['GET', 'POST', 'HEAD']).
 -define(HTTP_1_1_METHODS, ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE',
                            'CONNECT', 'OPTIONS']).


### PR DESCRIPTION
Change 1: Include the stacktrace in errors caught at the mochiweb level. This resolves #171 by getting the stacktrace into an error message generated from a failed `init` resource function.

Change 2: Don't supress warnings about `erlang:get_stacktrace/0` being deprecated. With `wm_compat.hrl` and `rebar.config.script` that call should never appear in OTP 21+ code. We want the warning if it does.