### PR TITLE
log size of response as zero bytes for HEAD requests (#189)

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -419,7 +419,7 @@ send_response(CodeAndPhrase, PassedState=#wm_reqstate{reqdata=RD}, _Req) ->
          make_headers(
            webmachine_status_code:status_code(CodeAndPhrase), Length, RD)]),
     FinalLength = case wrq:method(RD) of
-         'HEAD' -> Length;
+         'HEAD' -> 0; % no body sent
          _ ->
             case Body of
                 {stream, Body2} ->


### PR DESCRIPTION
No body was sent. Zero is the correct number of bytes to record (and that seems to be how other webservers log it as well).

Apache actually logs a hyphen "`-`" instead of zero, but to break as few custom loggers as possible, zero seemed like the safer bet.