### PR TITLE
don't exit(normal) on errors from mochiweb_socket:send

### DIFF
--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -185,7 +185,7 @@ handle_error(Code, Error, Req) ->
     {ErrorHTML,Req1} =
         ErrorHandler:render_error(Code, Req, Error),
     {ok,Req2} = webmachine_request:append_to_response_body(ErrorHTML, Req1),
-    {ok,Req3} = webmachine_request:send_response(Code, Req2),
+    {_Result,Req3} = webmachine_request:send_response(Code, Req2),
     {LogData,_ReqState4} = webmachine_request:log_data(Req3),
     spawn(webmachine_log, log_access, [LogData]),
     ok.


### PR DESCRIPTION
This addresses both #59 and #290.

For #59, the `normal` exit would happen before logging and tracing could be done. So if a client did something like disconnect early, and the send returned `{error, enotconn}`, no evidence of that request would be recorded.

For #290, the `normal` exit could fail to clean up resources in linked processes. Mochiweb has since changed (in 3.0.0 via mochi/mochiweb@e56a4dc) its `normal` exits to `{shutdown, Error}` exits, which will terminate linked processes correctly, as long as webmachine hasn't exit-normal'd first.

This change bubbles the error from send up through the various send helpers, in an attempt to short-circuit things like stream body producers, so as not to waste resources producing bodies that can't be sent. (The exception is "writer" body producers, which have no facility to detect such errors.) This makes the exit-shutdown change in mochiweb doubly important, since a stream can't rely on running to its end to shutdown. It couldn't rely on this anyway, with webmachine's exit-normal, but it was still effective in some circumstances.

An added benefit is that logging now records the number of bytes attempted to be sent before receiving an error, instead of the full size of the stream (since `{error, closed}` was ignored and allowed the stream to be read in full).