### PR TITLE
Consume request body or add Connection: close header

### DIFF
--- a/src/webmachine.app.src
+++ b/src/webmachine.app.src
@@ -21,6 +21,9 @@
     %% module that has rewrite/5
    ,{server_name, undefined}
     %% string() for the "Server" response header
+   ,{max_flush_bytes, 67108864}
+    %% maximum number of bytes to read from a request body that was
+    %% ignored before giving up and closing the connection (64MB default)
    ]},
 
   {maintainers,["Sean Cribbs", "Joe DeVivo", "Bryan Fink",

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -224,6 +224,8 @@ call({stream_req_body, MaxHunk}, {?MODULE, ReqState}) ->
             {recv_stream_body(ReqState, MaxHunk),
              ReqState#wm_reqstate{bodyfetch=stream}}
     end;
+call(maybe_flush_req_body, {?MODULE, ReqState}) ->
+    {maybe_flush_req_body(ReqState), ReqState};
 call(resp_headers, {?MODULE, ReqState}) ->
     {wrq:resp_headers(ReqState#wm_reqstate.reqdata), ReqState};
 call(resp_redirect, {?MODULE, ReqState}) ->
@@ -493,29 +495,41 @@ read_whole_stream({Hunk,Next}, Acc0, MaxRecvBody, SizeAcc) ->
             end
     end.
 
-recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
-    put(mochiweb_request_recv, true),
+expects_continue(PassedState) ->
     case get_header_value("expect", PassedState) of
         {undefined, _} ->
-            ok;
+            false;
         {Continue, _} ->
-            case string:to_lower(Continue) of
-                "100-continue" ->
-                    send(PassedState#wm_reqstate.socket,
-                         [make_version(wrq:version(RD)),
-                          make_code(100), <<"\r\n\r\n">>]);
-                _ ->
-                    ok
-            end
+            string:to_lower(Continue) =:= "100-continue"
+    end.
+
+sent_continue() ->
+    get(webmachine_sent_continue) =:= true.
+
+recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
+    case expects_continue(PassedState) and (not sent_continue()) of
+        true ->
+            put(webmachine_sent_continue, true),
+            send(PassedState#wm_reqstate.socket,
+                 [make_version(wrq:version(RD)),
+                  make_code(100), <<"\r\n\r\n">>]);
+        _ ->
+            ok
     end,
     case body_length(PassedState) of
         {unknown_transfer_encoding, X} -> exit({unknown_transfer_encoding, X});
-        undefined -> {<<>>, done};
-        0 -> {<<>>, done};
-        chunked -> recv_chunked_body(PassedState#wm_reqstate.socket,
-                                     MaxHunkSize);
-        Length -> recv_unchunked_body(PassedState#wm_reqstate.socket,
-                                      MaxHunkSize, Length)
+        undefined ->
+            record_stream_progress(done),
+            {<<>>, done};
+        0 ->
+            record_stream_progress(done),
+            {<<>>, done};
+        chunked ->
+            start_recv_chunked_body(PassedState#wm_reqstate.socket,
+                                    MaxHunkSize);
+        Length ->
+            recv_unchunked_body(PassedState#wm_reqstate.socket,
+                                MaxHunkSize, Length)
     end.
 
 recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
@@ -523,6 +537,7 @@ recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
         true ->
             case mochiweb_socket:recv(Socket,DataLeft,?IDLE_TIMEOUT) of
                 {ok,Data1} ->
+                    record_stream_progress(done),
                     {Data1, done};
                 {error, Error} ->
                     throw({webmachine_recv_error, Error})
@@ -530,39 +545,47 @@ recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
         false ->
             case mochiweb_socket:recv(Socket,MaxHunk,?IDLE_TIMEOUT) of
                 {ok,Data2} ->
-                    {Data2,
-                     fun() ->
-                             recv_unchunked_body(
-                               Socket, MaxHunk, DataLeft-MaxHunk)
-                     end};
+                    Next = fun() ->
+                                   recv_unchunked_body(Socket, MaxHunk,
+                                                       DataLeft-MaxHunk)
+                           end,
+                    record_stream_progress(Next),
+                    {Data2, Next};
                 {error, Error} ->
                     throw({webmachine_recv_error, Error})
             end
     end.
 
-recv_chunked_body(Socket, MaxHunk) ->
+start_recv_chunked_body(Socket, MaxHunk) ->
     case read_chunk_length(Socket, false) of
-        0 -> {<<>>, done};
-        ChunkLength -> recv_chunked_body(Socket,MaxHunk,ChunkLength)
+        0 ->
+            record_stream_progress(done),
+            {<<>>, done};
+        ChunkLength ->
+            recv_chunked_body(Socket,MaxHunk, ChunkLength)
     end.
 recv_chunked_body(Socket, MaxHunk, LeftInChunk) ->
     case MaxHunk >= LeftInChunk of
         true ->
             case mochiweb_socket:recv(Socket,LeftInChunk,?IDLE_TIMEOUT) of
                 {ok,Data1} ->
-                    {Data1,
-                     fun() -> recv_chunked_body(Socket, MaxHunk) end};
+                    Next = fun() ->
+                                   start_recv_chunked_body(Socket, MaxHunk)
+                           end,
+                    record_stream_progress(Next),
+                    {Data1, Next};
                 {error, Error} ->
                     throw({webmachine_recv_error, Error})
             end;
         false ->
             case mochiweb_socket:recv(Socket,MaxHunk,?IDLE_TIMEOUT) of
                 {ok,Data2} ->
-                    {Data2,
-                     fun() ->
-                             recv_chunked_body(
-                               Socket, MaxHunk, LeftInChunk-MaxHunk)
-                     end};
+                    Next = fun() ->
+                                   recv_chunked_body(Socket, MaxHunk,
+                                                     LeftInChunk-MaxHunk)
+                           end,
+                    record_stream_progress(Next),
+                    {Data2, Next};
                 {error, Error} ->
                     throw({webmachine_recv_error, Error})
             end
@@ -592,6 +615,49 @@ read_chunk_length(Socket, MaybeLastChunk) ->
         {error, Error} ->
             throw({webmachine_recv_error, Error})
     end.
+
+record_stream_progress(Remaining) ->
+    put(webmachine_stream_progress, Remaining).
+
+get_stream_progress() ->
+    get(webmachine_stream_progress).
+
+maybe_flush_req_body(Req) ->
+    case get_stream_progress() of
+        done ->
+            %% Let mochiweb know that we completed reading the body
+            %% that came with the request, or it will close the
+            %% socket.
+            put(mochiweb_request_recv, true),
+            true;
+        undefined ->
+            case expects_continue(Req) and (not sent_continue()) of
+                true ->
+                    %% If the request expected continue, but we didn't
+                    %% send it, then tell mochiweb to ignore what the
+                    %% content length or transfer encoding says about
+                    %% a body.
+                    put(mochiweb_request_recv, true),
+                    true;
+                false ->
+                    %% There might be a body sitting out there we
+                    %% haven't read - give it a try.
+                    flush_req_body(catch recv_stream_body(Req, 65535))
+            end;
+        Next ->
+            %% request processing stopped in the middle of a stream -
+            %% can we finish it?
+            flush_req_body(catch Next())
+    end.
+
+flush_req_body({webmachine_recv_error, _}) ->
+    false;
+flush_req_body({_Bytes, done}) when is_binary(_Bytes) ->
+    put(mochiweb_request_recv, true),
+    true;
+flush_req_body({_Bytes, Next}) when is_binary(_Bytes), is_function(Next) ->
+    flush_req_body(catch Next()).
+
 
 get_range({?MODULE, #wm_reqstate{reqdata = RD}=ReqState}=Req) ->
     case RD#wm_reqdata.resp_range of

--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -650,8 +650,9 @@ maybe_flush_req_body(Req) ->
                         _ ->
                             %% There might be a body sitting out there we
                             %% haven't read - give it a try.
-                            flush_req_body(catch recv_stream_body(Req, 65535),
-                                           MaxFlush)
+                            ReadSize = erlang:min(65535, MaxFlush),
+                            flush_req_body(
+                              catch recv_stream_body(Req, ReadSize), MaxFlush)
                     end
             end;
         Next ->

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -317,8 +317,7 @@ core_tests() ->
      fun extension_status_code/0,
      fun extension_status_code_with_phrase/0,
      fun extension_status_code_default_phrase/0,
-     fun code_specific_error_bodies/0,
-     fun same_inets_for_post_calls/0
+     fun code_specific_error_bodies/0
      % known_failure -- fun stream_content_md5/0
     ].
 
@@ -1373,19 +1372,6 @@ code_specific_error_bodies() ->
                  {re:run(Body500, "The server encountered an error while"),
                   Body500}),
     ok.
-
-same_inets_for_post_calls() ->
-    put_setting(is_authorized, "Basic realm=decsisioncoretest"),
-    put_setting(content_types_accepted, [{"text/plain", accept_text}]),
-    put_setting(allowed_methods, ?HTTP_1_1_METHODS),
-    put_setting(resource_exists, true),
-    lists:foreach(fun (_) ->
-            {ok, {{_, Status1, Body}, _, _}} =
-                httpc:request(post, {url("post"), [], "text/plain", "{\"hello\":\"world\"}"}, [], []),
-            ?assertMatch({401, _}, {Status1, Body}),
-            ok
-        end,
-        lists:seq(1, 100)).
 
 
 %% 201 result via P11 from a POST with a streaming/chunked body and an MD5-sum

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -317,7 +317,8 @@ core_tests() ->
      fun extension_status_code/0,
      fun extension_status_code_with_phrase/0,
      fun extension_status_code_default_phrase/0,
-     fun code_specific_error_bodies/0
+     fun code_specific_error_bodies/0,
+     fun same_inets_for_post_calls/0
      % known_failure -- fun stream_content_md5/0
     ].
 
@@ -1372,6 +1373,19 @@ code_specific_error_bodies() ->
                  {re:run(Body500, "The server encountered an error while"),
                   Body500}),
     ok.
+
+same_inets_for_post_calls() ->
+    put_setting(is_authorized, "Basic realm=decsisioncoretest"),
+    put_setting(content_types_accepted, [{"text/plain", accept_text}]),
+    put_setting(allowed_methods, ?HTTP_1_1_METHODS),
+    put_setting(resource_exists, true),
+    lists:foreach(fun (_) ->
+            {ok, {{_, Status1, Body}, _, _}} =
+                httpc:request(post, {url("post"), [], "text/plain", "{\"hello\":\"world\"}"}, [], []),
+            ?assertMatch({401, _}, {Status1, Body}),
+            ok
+        end,
+        lists:seq(1, 100)).
 
 
 %% 201 result via P11 from a POST with a streaming/chunked body and an MD5-sum

--- a/test/multi_request_connection_test.erl
+++ b/test/multi_request_connection_test.erl
@@ -1,0 +1,298 @@
+%% A batch of tests to verify that Webmachine can properly handle
+%% multiple requests on the same connection in various situations.
+%%
+%% This is mostly regression tests to verify that the mechanism that
+%% ensures that request bodies get read before request processing
+%% finishes.
+-module(multi_request_connection_test).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+         init/1,
+         allowed_methods/2,
+         content_types_provided/2,
+         content_types_accepted/2,
+         echo_disp_path/2,
+         process_post/2,
+         echo_partial_body/2,
+         is_authorized/2,
+         delete_resource/2,
+         delete_completed/2
+        ]).
+
+%%% TESTS
+
+multi_req_tests() ->
+    [
+     fun double_get/1,
+     fun post_then_get/1,
+     fun unauthorized_post_then_get/1,
+     fun too_large_unauthorized_post_then_get/1,
+     fun half_chunk_then_get/1,
+     fun half_unchunk_then_get/1,
+     fun delete_with_body_then_get/1
+    ].
+
+%% Two GETs is the simplest happy-path, because there are no bodies to
+%% skip.
+double_get(Ctx) ->
+    DispPath1 = "get1",
+    DispPath2 = "get2",
+    Req1 = build_request("GET", DispPath1, [], []),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath1}, hd(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%% Successful POST then GET is the next simplest happy-path, because
+%% the resource should have consumed the POST body.
+post_then_get(Ctx) ->
+    DispPath1 = "post1",
+    DispPath2 = "get3",
+    Req1 = build_request("POST", DispPath1,
+                         [{"content-type", "text/plain"}], "check"),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 204"++_, _, []}, hd(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%% First real body-skipping test. The POST is unauthorized, so the
+%% resource never reads its body.
+unauthorized_post_then_get(Ctx) ->
+    DispPath1 = "unauth",
+    DispPath2 = "get4",
+    Req1 = build_request("POST", DispPath1,
+                         [{"content-type", "text/plain"}], "check"),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 401"++_, _, _}, hd(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%% This time the unread body is larger than we are prepared to skip,
+%% so the GET _does_ get ignored.
+too_large_unauthorized_post_then_get(Ctx) ->
+    DispPath1 = "unauth",
+    DispPath2 = "get5",
+    ReqBody = "This is a moderately sized string.",
+    Req1 = build_request("POST", DispPath1,
+                         [{"content-type", "text/plain"}], ReqBody),
+    Req2 = build_request("GET", DispPath2, [], []),
+    {ok, RestoreMaxFlush} = application:get_env(webmachine, max_flush_bytes),
+    application:set_env(webmachine, max_flush_bytes, length(ReqBody)-3),
+    Responses = try send_requests(Ctx, [Req1, Req2])
+                after
+                    application:set_env(
+                      webmachine, max_flush_bytes, RestoreMaxFlush)
+                end,
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 401"++_, _, _}, hd(Responses)),
+    {ok, _, Headers, _} = hd(Responses),
+    ?assertEqual({"Connection", "close"},
+                 lists:keyfind("Connection", 1, Headers)),
+    ?assertMatch({error, closed}, hd(tl(Responses))),
+    ok.
+
+%% Here PUT processing begins to stream an unchunked body, but does
+%% not finish. The flush mechanism should pick up where it left off.
+half_unchunk_then_get(Ctx) ->
+    DispPath1 = "put1",
+    DispPath2 = "get6",
+    ReqBody = "This is a string containing more than twelve bytes.",
+    Req1 = build_request("PUT", DispPath1,
+                         [{"content-type", "text/plain"}], ReqBody),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, _}, hd(Responses)),
+    {ok, _, _, RespBody} = hd(Responses),
+    %% if these RespBody asserts fail, the test is invalid because the
+    %% whole request body was read by the resource
+    ?assertEqual(1, string:str(ReqBody, RespBody)),
+    ?assert(length(RespBody) < length(ReqBody)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%% Here PUT processing begins to stream a chunked body, but does not
+%% finish. The flush mechanism should pick up where it left off.
+half_chunk_then_get(Ctx) ->
+    DispPath1 = "put2",
+    DispPath2 = "get7",
+    ReqBody = ["This is", " a string", " containing",
+               " more than", " twelve bytes."],
+    Req1 = build_request("PUT", DispPath1,
+                         [{"content-type", "text/plain"}], {chunked, ReqBody}),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, _}, hd(Responses)),
+    {ok, _, _, RespBody} = hd(Responses),
+    %% if these RespBody asserts fail, the test is invalid because the
+    %% whole request body was read by the resource
+    ?assertEqual(1, string:str(lists:flatten(ReqBody), RespBody)),
+    ?assert(length(RespBody) < length(lists:flatten(ReqBody))),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%% DELETE with a body was specifically handled before the introduction
+%% of webmachine_request:maybe_flush_req_body. Does it still work?
+delete_with_body_then_get(Ctx) ->
+    DispPath1 = "delete1",
+    DispPath2 = "get8",
+    Req1 = build_request("DELETE", DispPath1,
+                         [{"content-type", "text/plain"}], "check"),
+    Req2 = build_request("GET", DispPath2, [], []),
+    Responses = send_requests(Ctx, [Req1, Req2]),
+    ?assertEqual(2, length(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 204"++_, _, []}, hd(Responses)),
+    ?assertMatch({ok, "HTTP/1.1 200"++_, _, DispPath2}, hd(tl(Responses))),
+    ok.
+
+%%% SUPPORT/UTIL
+
+build_request(Method, Path, Headers, Body) ->
+    [Method, " /", atom_to_list(?MODULE), "/", Path, " HTTP/1.1\r\n",
+     [ [K, ": ", V, "\r\n"] || {K, V} <- Headers ],
+     case Body of
+         [] ->
+             "\r\n";
+         {chunked, Chunks} ->
+             [["Transfer-encoding: chunked\r\n\r\n"
+              |[build_chunk(C) || C <- Chunks]]
+             |"0\r\n\r\n"];
+         _ ->
+             ["Content-length: ", integer_to_list(length(Body)), "\r\n\r\n",
+              Body]
+     end].
+
+build_chunk(Bytes) ->
+    [mochihex:to_hex(length(Bytes)), "\r\n", Bytes, "\r\n"].
+
+%% httpc, ibrowse, curl etc. will all reuse a connection ... when they
+%% think they should. For these tests we need to force the requests to
+%% be sent on the same connection, so we'll marshal bytes onto and off
+%% of the socket directly.
+send_requests(Ctx, RequestList) ->
+    {ok, Sock} = gen_tcp:connect("localhost",
+                                 wm_integration_test_util:get_port(Ctx),
+                                 [list, {active, false}]),
+    ok = gen_tcp:send(Sock, iolist_to_binary(RequestList)),
+    Responses = receive_responses(Sock, length(RequestList)),
+    gen_tcp:close(Sock),
+    Responses.
+
+receive_responses(Sock, ResponseCount) ->
+    [ receive_response(Sock) || _ <- lists:seq(1, ResponseCount) ].
+
+receive_response(Sock) ->
+    case gen_tcp:recv(Sock, 0, 2000) of
+        {error, _} = Error ->
+            Error;
+        {ok, Data} ->
+            [Head|MaybeBody] = string:split(Data, "\r\n\r\n"),
+            [Code|RawHeaders] = string:tokens(Head, "\r\n"),
+            Headers = [ list_to_tuple(string:tokens(H, ": "))
+                        || H <- RawHeaders ],
+            BodyLength = case lists:keyfind("Content-Length", 1, Headers) of
+                             {_, Lstr} ->
+                                 list_to_integer(Lstr);
+                             false ->
+                                 0
+                         end,
+            StartBody = lists:flatten(MaybeBody),
+            Body = receive_body(Sock,
+                                BodyLength-length(StartBody),
+                                [StartBody]),
+            {ok, Code, Headers, Body}
+    end.
+
+receive_body(_Sock, 0, Acc) ->
+    lists:flatten(lists:reverse(Acc));
+receive_body(Sock, Remaining, Acc) when Remaining > 0 ->
+    case gen_tcp:recv(Sock, Remaining, 2000) of
+        {ok, BodyData} ->
+            receive_body(Sock, Remaining-length(BodyData), [BodyData|Acc]);
+        {error, _} = Error ->
+            Error
+    end.
+
+%%% REQUEST MODULE
+
+init([]) ->
+    {ok, undefined}.
+
+allowed_methods(RD, Ctx) ->
+    {['GET','HEAD','OPTIONS','POST','PUT','DELETE'], RD, Ctx}.
+
+content_types_provided(RD, Ctx) ->
+    {[{"text/plain", echo_disp_path}], RD, Ctx}.
+
+content_types_accepted(RD, Ctx) ->
+    {[{"text/plain", echo_partial_body}], RD, Ctx}.
+
+echo_disp_path(RD, Ctx) ->
+    {wrq:disp_path(RD), RD, Ctx}.
+
+delete_resource(RD, Ctx) ->
+    %% do not check for a request body!
+    {true, RD, Ctx}.
+
+delete_completed(RD, Ctx) ->
+    {true, RD, Ctx}.
+
+is_authorized(RD, Ctx) ->
+    case wrq:disp_path(RD) of
+        "unauth" ->
+            {"Basic realm=multireqtest", RD, Ctx};
+        _ ->
+            {true, RD, Ctx}
+    end.
+
+% POST reads the request body in "standard" non-streaming
+process_post(RD, Ctx) ->
+    _Body = wrq:req_body(RD),
+    {true, RD, Ctx}.
+
+% PUT reads twelve bytes of the body in streaming mode
+echo_partial_body(RD, Ctx) ->
+    Bytes = stream(2, wrq:stream_req_body(RD, 4)),
+    RD2 = wrq:set_resp_header("content-type", "text/plain", RD),
+    RD3 = wrq:set_resp_body(Bytes, RD2),
+    {true, RD3, Ctx}.
+
+stream(Count, {Bytes, Stream}) ->
+    lists:flatten(
+      lists:reverse(
+        element(2, lists:foldl(fun(_, {S, Acc}) ->
+                                       {B, Next} = S(),
+                                       {Next, [B|Acc]}
+                               end,
+                               {Stream, [Bytes]},
+                               lists:seq(1, Count))))).
+
+
+%%% TEST SETUP
+
+multireq_test_() ->
+    {foreach,
+     %% Setup
+     fun() ->
+             DL = [{[atom_to_list(?MODULE), '*'], ?MODULE, []}],
+             wm_integration_test_util:start(?MODULE, "0.0.0.0", DL)
+     end,
+     %% Cleanup
+     fun(Ctx) ->
+             wm_integration_test_util:stop(Ctx)
+     end,
+     %% Test functions provided with context from setup
+     [fun(Ctx) ->
+              {spawn, {with, Ctx, multi_req_tests()}}
+      end]}.
+
+-endif.


### PR DESCRIPTION
Another large change … sorry @seancribbs. It's 70% test code. ✅

This resolves both #168 and #232. Just before sending the response, we now check to see if there is a request body that was not - or not fully - consumed. If there is, we attempt to consume it. If we can't, we add a "Connection: closed" header. This is because if we let an unconsumed request body get back to mochiweb, it will close the socket. Closing the socket without reading the request body causes problems for some clients. So, we're doing what we can to help them.

The major change to `webmachine_request` is to stash details about the request body consumption in the process dictionary. This allows the end-of-processing machinery to tell whether the whole request body was read, and to access the "Next()" stream body function in the case that the resource stopped part way through reading the body.

A new configuration parameter is also added, to provide some protection against malicious clients sending (potentially infinitely) large request bodies. Webmachine will attempt to flush at most 64MB before closing the connection.

The best way I could figure out to test this was to directly send two requests over the same socket, and check whether they both received responses. All of the http clients can do this, but none of them expose whether they did this. So, it's a bunch of `gen_tcp` calls to make sure all the bytes went over a single socket.

Three of the new tests passed before this change:

1. `double_get`. There are no request bodies here at all. This is just a simple test to make sure that Webmachine can actually handle two requests on the same socket. I'm not sure there was an explicit test verifying this otherwise.
2. `post_then_get`. There is a request body here, but the resource fully consumes it.
3. `delete_with_body_then_get`. Code had been added to decision core specifically to consume the bodies of DELETE requests. This code has been removed in favor of this general solution.

The other tests fail before this change because unconsumed request bodies cause mochiweb to close the connection, so the second request is not processed. Except for `too_large_unauthorized_post_then_get`, which fails because it can't read the new configuration value, but also expects the second request not to be processed because the unconsumed body of the first request was too large.