### PR TITLE
stop and close connection on body-sending error

### DIFF
--- a/src/webmachine_error_log_handler.erl
+++ b/src/webmachine_error_log_handler.erl
@@ -127,6 +127,12 @@ format_req(error, 503, Req, _) ->
     {Path, _} = webmachine_request:path(Req),
     Reason = "Webmachine cannot fulfill the request at this time",
     ["[error] ", Reason, ": path=", Path, $\n];
+format_req(error, 500, Req, {stream_error, Reason}) ->
+    {Path, _} = webmachine_request:path(Req),
+    Str = io_lib:format("~p", [Reason]),
+    ["[error] Webmachine encountered an error while streaming the response."
+     " path=", Path, $\n,
+     "        ", Str, $\n];
 format_req(error, _Code, Req, Reason) ->
     {Path, _} = webmachine_request:path(Req),
     Str = io_lib:format("~p", [Reason]),

--- a/test/stream_error_test.erl
+++ b/test/stream_error_test.erl
@@ -1,0 +1,155 @@
+%% A batch of tests to verify that errors encountered during stream
+%% production are handled correctly.
+%%
+%% These cases used to cause the stream to be re-evaluated and sent
+%% twice, with an error appended after that. See
+%% https://github.com/webmachine/webmachine/issues/60.
+-module(stream_error_test).
+-include("webmachine_logger.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+         init/1,
+         content_types_provided/2,
+         provide_chunked_text/2,
+         provide_unchunked_text/2,
+         provide_writer_text/2
+        ]).
+
+%%% TESTS
+
+stream_error_tests() ->
+    [
+     fun chunked_stream_stops/1,
+     fun unchunked_stream_stops/1,
+     fun writer_stops/1
+    ].
+
+%% General test for the "_stops" tests. This contacts a resource that
+%% purposely hits an error in its stream-producing function.
+stream_stops(Ctx, Type, ExpectBody, ExpectLength) ->
+    WaitRef = test_log_handler:clear_logs(),
+    Socket = open_stream_stop_request(Ctx, Type),
+    Logs = test_log_handler:wait_for_logs(
+             WaitRef, #{log_error => 1, log_access => 1}),
+    %% Logging happens after response sending, so if we
+    %% wait until logging happens, we can probably just
+    %% read without delay.
+    Response = read_until_close(Socket),
+
+    %% We expect a success response code
+    ?assertMatch("HTTP/1.1 200 OK"++_, Response),
+
+    %% We should only see the partial stream once
+    ?assertEqual(string:find(Response, ExpectBody, leading),
+                 string:find(Response, ExpectBody, trailing)),
+
+    %% The body should have only one response (checking for one status
+    %% line here), NOT the start of the stream plus an error
+    ?assertEqual(string:find(Response, "HTTP/1.1", leading),
+                 string:find(Response, "HTTP/1.1", trailing)),
+
+    %% the stream error should show up in an error log
+    ErrorLog = lists:keyfind(log_error, 1, Logs),
+    ?assertMatch({log_error, 500, _, {stream_error, _}}, ErrorLog),
+
+    %% number of bytes sent before error should be correct
+    AccessLog = lists:keyfind(log_access, 1, Logs),
+    ?assertMatch({log_access,
+                  #wm_log_data{response_length=ExpectLength}},
+                 AccessLog).
+
+chunked_stream_stops(Ctx) ->
+    %% Chunked encoding only counts bytes of data, not length and line
+    %% endings.
+    Expectlength = 5,
+    stream_stops(Ctx, "text/chunked",
+                 string:copies("\r\n1\r\nx", 5), Expectlength).
+
+unchunked_stream_stops(Ctx) ->
+    %% Unchunked streaming reports all bytes sent, even if stopped in
+    %% the middle.
+    ExpectLength = 10,
+    stream_stops(Ctx, "text/unchunked",
+                 string:copies("x", 5), ExpectLength).
+
+writer_stops(Ctx) ->
+    %% Writer reports only data bytes, not chunk length and line
+    %% endings.
+    ExpectLength = 5,
+    stream_stops(Ctx, "text/writer", "\r\n5\r\nxxxxx", ExpectLength).
+
+%%% SUPPORT/UTIL
+
+open_stream_stop_request(Ctx, ContentType) ->
+    Request = ["GET ", "/", atom_to_list(?MODULE), " HTTP/1.1\r\n",
+               "Accept: ", ContentType, "\r\n\r\n"],
+    {ok, Sock} = gen_tcp:connect("localhost",
+                                 wm_integration_test_util:get_port(Ctx),
+                                 [list, {active, false}]),
+    ok = gen_tcp:send(Sock, iolist_to_binary(Request)),
+    Sock.
+
+read_until_close(Sock) ->
+    read_until_close(Sock, gen_tcp:recv(Sock, 0, 100), []).
+
+read_until_close(Sock, {ok, Data}, Acc) ->
+    read_until_close(Sock, gen_tcp:recv(Sock, 0, 100), [Data|Acc]);
+read_until_close(Sock, {error, _}, Acc) ->
+    gen_tcp:close(Sock),
+    lists:flatten(lists:reverse(Acc)).
+
+%%% REQUEST MODULE
+
+init([]) ->
+    {ok, undefined}.
+
+%% Using content type to pick the kind of stream the resource will use.
+content_types_provided(RD, Ctx) ->
+    {[{"text/chunked", provide_chunked_text},
+      {"text/unchunked", provide_unchunked_text},
+      {"text/writer", provide_writer_text}],
+     RD, Ctx}.
+
+provide_chunked_text(RD, Ctx) ->
+    {{stream, {<<"x">>, fun() -> stream(4) end}}, RD, Ctx}.
+
+provide_unchunked_text(RD, Ctx) ->
+    %% the 10 is a lie
+    {{known_length_stream, 10, {<<"x">>, fun() -> stream(4) end}}, RD, Ctx}.
+
+stream(0) ->
+    this_call:is_not_defined(should_cause_error);
+stream(N) ->
+    {<<"x">>, fun() -> stream(N-1) end}.
+
+provide_writer_text(RD, Ctx) ->
+    {{writer, fun writer/1}, RD, Ctx}.
+
+writer(Sender) ->
+    Sender(<<"xxxxx">>),
+    this_call:is_not_defined(should_cause_error).
+
+%%% TEST SETUP
+
+stream_error_test_() ->
+    {foreach,
+     %% Setup
+     fun() ->
+             DL = [{[atom_to_list(?MODULE), '*'], ?MODULE, []}],
+             Ctx = wm_integration_test_util:start(?MODULE, "0.0.0.0", DL),
+             webmachine_log:add_handler(test_log_handler, []),
+             Ctx
+     end,
+     %% Cleanup
+     fun(Ctx) ->
+             wm_integration_test_util:stop(Ctx)
+     end,
+     %% Test functions provided with context from setup
+     [fun(Ctx) ->
+              {spawn, {with, Ctx, stream_error_tests()}}
+      end]}.
+
+-endif.

--- a/test/test_log_handler.erl
+++ b/test/test_log_handler.erl
@@ -1,0 +1,110 @@
+%% A simple log handler to support testing logging outcomes.
+%%
+%% This log handler just holds logs it receives in an in-memory list
+%% until asked for them. Retrieve accumulated logs by calling either
+%% `get_logs/0` or `wait_for_logs/2`.
+-module(test_log_handler).
+-export([
+         init/1,
+         handle_call/2,
+         handle_event/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3,
+         get_logs/0,
+         clear_logs/0,
+         wait_for_logs/2
+        ]).
+-record(state, {logs, waiter}).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% GEN EVENT CALLBACKS
+
+init([]) ->
+    {ok, #state{logs=[], waiter=undefined}}.
+
+handle_call({get_logs, Waiter}, State) ->
+    case State#state.logs of
+        [] ->
+            Ref = make_ref(),
+            {ok, {wait, Ref}, State#state{waiter={Waiter, Ref}}};
+        Logs ->
+            {ok, Logs, State#state{logs=[]}}
+    end.
+
+handle_event({log_error, _}=Log, #state{logs=OldLogs}=State) ->
+    {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
+handle_event({log_error, _, _, _}=Log, #state{logs=OldLogs}=State) ->
+    {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
+handle_event({log_access, _}=Log, #state{logs=OldLogs}=State) ->
+    {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
+handle_event({log_info, _}=Log, #state{logs=OldLogs}=State) ->
+    {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
+handle_event(_Event, State) ->
+    ?debugMsg("unknown logged!"),
+    ?debugVal(_Event),
+    {ok, State}.
+
+maybe_send_logs(#state{logs=Logs, waiter={Waiter, Ref}}) ->
+    Waiter ! {Ref, Logs},
+    #state{logs=[], waiter=undefined};
+maybe_send_logs(State) ->
+    State.
+
+handle_info(_Info, State) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% TEST QUERY API
+
+%% Get the accumulated logs. If no logs have been received by the
+%% handler, a `{wait, ref()}` tuple is returned instead, and a
+%% `{ref(), [Log]}` message will be sent when the next log is
+%% received. The accumulated logs are cleared from the handler.
+-spec get_logs() -> [any()] | {wait, reference()}.
+get_logs() ->
+    webmachine_log:call(test_log_handler, {get_logs, self()}).
+
+%% Call `get_logs` until it tells us to wait.
+-spec clear_logs() -> {wait, reference()}.
+clear_logs() ->
+    case get_logs() of
+        {wait, _}=WaitRef ->
+            WaitRef;
+        _OldLogs ->
+            clear_logs()
+    end.
+
+%% Keep reading logs until the specified amount of each type have been
+%% read. The amount of each type is specified by a map passed as the
+%% second parameter. The keys of the map should be the same as the
+%% first element of the log event (i.e. log_info, log_error, or
+%% log_access), and the values should be the number of logs of that
+%% type to wait for.
+wait_for_logs(RefOrLogs, TypeCounts) ->
+    wait_for_logs(RefOrLogs, TypeCounts, []).
+
+wait_for_logs({wait, Ref}, TypeCounts, OldLogs) ->
+    receive {Ref, NewLogs} -> wait_for_logs(NewLogs, TypeCounts, OldLogs) end;
+wait_for_logs(NewLogs, TypeCounts, OldLogs) ->
+    {NewCounts, Logs} =
+        lists:foldl(
+          fun(Log, {AccCounts, AccLogs}) ->
+              TypeCount = max(0, maps:get(element(1, Log), AccCounts, 0) - 1),
+              NewCounts = AccCounts#{element(1, Log) => TypeCount},
+              {NewCounts, [Log|AccLogs]}
+          end,
+          {TypeCounts, OldLogs},
+          NewLogs),
+    case maps:fold(fun(_, V, A) -> V+A end, 0, NewCounts) of
+        0 ->
+            Logs;
+        _ ->
+            wait_for_logs(get_logs(), NewCounts, Logs)
+    end.


### PR DESCRIPTION
If an error occurs while sending the body of the response, just stop and close the connection. This prevents the problem reported in issue #60, where an error in a streaming response body causes the stream to be evaluated twice (the second time came after the error handler was engaged, and returned the same stream-body definition, because it couldn't tell whether the resource rendered its own error message).

This is a little more invasive than just catching any errors from `send_body`, in order to report the number of bytes actually sent more accurately in the access logger.

While an error message is no longer included in the response body, an error is logged by the error log handler.