### PR TITLE
do not call log_error from error_handler; use notes

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -121,6 +121,7 @@ error_response(Reason) ->
 -spec error_response(webmachine_status:status_code_with_phrase(), any()) -> ok.
 error_response(CodeAndPhrase, Reason) ->
     EndTime = erlang:monotonic_time(),
+    wrcall({add_note, error, Reason}),
     {ok, ErrorHandler} = application:get_env(webmachine, error_handler),
     {ErrorHTML, ReqState} = ErrorHandler:render_error(
                               CodeAndPhrase,

--- a/src/webmachine_log.erl
+++ b/src/webmachine_log.erl
@@ -34,7 +34,6 @@
          log_access/1,
          log_close/3,
          log_error/1,
-         log_error/3,
          log_info/1,
          log_open/1,
          log_open/2,
@@ -140,11 +139,6 @@ log_close(Mod, Name, FD) ->
 -spec log_error(iolist()) -> ok.
 log_error(LogMsg) ->
     gen_event:sync_notify(?EVENT_LOGGER, {log_error, LogMsg}).
-
-%% @doc Notify registered log event handler of an error event.
--spec log_error(pos_integer(), webmachine_request:t(), term()) -> ok.
-log_error(Code, Req, Reason) ->
-    gen_event:sync_notify(?EVENT_LOGGER, {log_error, Code, Req, Reason}).
 
 %% @doc Notify registered log event handler of an info event.
 -spec log_info(iolist()) -> ok.

--- a/test/test_log_handler.erl
+++ b/test/test_log_handler.erl
@@ -35,8 +35,6 @@ handle_call({get_logs, Waiter}, State) ->
 
 handle_event({log_error, _}=Log, #state{logs=OldLogs}=State) ->
     {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
-handle_event({log_error, _, _, _}=Log, #state{logs=OldLogs}=State) ->
-    {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
 handle_event({log_access, _}=Log, #state{logs=OldLogs}=State) ->
     {ok, maybe_send_logs(State#state{logs=[Log|OldLogs]})};
 handle_event({log_info, _}=Log, #state{logs=OldLogs}=State) ->


### PR DESCRIPTION
This is an attempt to untangle some error logging. It probably should have been two separate commits, but I didn't want to move old stuff just to replace it immediately. So, you get two changes in one.

The first change removes the `{log_error, Code, Req, Reason}` log event. Instead of directly sending such errors to the logging system, the error is now attached to the request via the "notes" feature. At the end of request processing, notes are included in the `#wm_log_data{}` record passed with the `log_access` event. The `webmachine_error_log_handler` now looks for these notes instead.

The second change moves the responsibility for recording these errors from `webmachine_error_handler` to whatever code is raising the error. I think this better separates the responsibilities of the two similarly-named modules: `webmachine_error_handler` just renders error response messages, while `webmachine_error_log_handler` handles deciding whether the error is worth logging.