### PR TITLE
remove tuple module support from webmachine_request

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -38,8 +38,7 @@ handle_request(Resource, ReqState) ->
 
 wrcall(X) ->
     RS0 = get(reqstate),
-    Req = webmachine_request:new(RS0),
-    {Response, RS1} = webmachine_request:call(X, Req),
+    {Response, RS1} = webmachine_request:call(X, RS0),
     put(reqstate, RS1),
     Response.
 
@@ -124,9 +123,7 @@ error_response(CodeAndPhrase, Reason) ->
     wrcall({add_note, error, Reason}),
     {ok, ErrorHandler} = application:get_env(webmachine, error_handler),
     {ErrorHTML, ReqState} = ErrorHandler:render_error(
-                              CodeAndPhrase,
-                              {webmachine_request,get(reqstate)},
-                              Reason),
+                              CodeAndPhrase, get(reqstate), Reason),
     put(reqstate, ReqState),
     wrcall({set_resp_body, encode_body(ErrorHTML)}),
     finish_response(CodeAndPhrase, EndTime).

--- a/src/webmachine_mochiweb.erl
+++ b/src/webmachine_mochiweb.erl
@@ -114,8 +114,7 @@ loop(MochiReq, Name) ->
     end.
 
 -spec new_webmachine_req(mochiweb_request()) ->
-                                {module(),#wm_reqstate{}}
-                                    |{{error, term()}, #wm_reqstate{}}.
+          #wm_reqstate{} |{{error, term()}, #wm_reqstate{}}.
 new_webmachine_req(Request) ->
     Method = mochiweb_request:get(method, Request),
     Scheme = mochiweb_request:get(scheme, Request),
@@ -149,25 +148,23 @@ new_webmachine_req(Request) ->
     InitState = #wm_reqstate{socket=Socket,
                              log_data=InitialLogData,
                              reqdata=InitialReqData},
-    InitReq = {webmachine_request,InitState},
 
-    case webmachine_request:get_peer(InitReq) of
+    case webmachine_request:get_peer(InitState) of
       {ErrorGetPeer = {error,_}, ErrorGetPeerReqState} ->
         % failed to get peer
-        { ErrorGetPeer, webmachine_request:new (ErrorGetPeerReqState) };
+        { ErrorGetPeer, ErrorGetPeerReqState };
       {Peer, _ReqState} ->
-        case webmachine_request:get_sock(InitReq) of
+        case webmachine_request:get_sock(InitState) of
           {ErrorGetSock = {error,_}, ErrorGetSockReqState} ->
             LogDataWithPeer = InitialLogData#wm_log_data {peer=Peer},
             ReqStateWithSockErr =
               ErrorGetSockReqState#wm_reqstate{log_data=LogDataWithPeer},
-            { ErrorGetSock, webmachine_request:new (ReqStateWithSockErr) };
+            { ErrorGetSock, ReqStateWithSockErr };
           {Sock, ReqState} ->
             ReqData = wrq:set_sock(Sock, wrq:set_peer(Peer, InitialReqData)),
             LogData =
               InitialLogData#wm_log_data {peer=Peer, sock=Sock},
-            webmachine_request:new(ReqState#wm_reqstate{log_data=LogData,
-                                                        reqdata=ReqData})
+            ReqState#wm_reqstate{log_data=LogData, reqdata=ReqData}
         end
     end.
 

--- a/src/wrq.erl
+++ b/src/wrq.erl
@@ -142,14 +142,13 @@ req_qs(_RD = #wm_reqdata{req_qs=QS}) when is_list(QS) -> QS.
 req_headers(_RD = #wm_reqdata{req_headers=ReqH}) -> ReqH.
 
 req_body(_RD = #wm_reqdata{wm_state=ReqState0,max_recv_body=MRB}) ->
-    Req = webmachine_request:new(ReqState0),
-    {ReqResp, ReqState} = webmachine_request:req_body(MRB, Req),
+    {ReqResp, ReqState} = webmachine_request:req_body(MRB, ReqState0),
     put(tmp_reqstate, ReqState),
     maybe_conflict_body(ReqResp).
 
 stream_req_body(_RD = #wm_reqdata{wm_state=ReqState0}, MaxHunk) ->
-    Req = webmachine_request:new(ReqState0),
-    {ReqResp, ReqState} = webmachine_request:stream_req_body(MaxHunk, Req),
+    {ReqResp, ReqState} =
+        webmachine_request:stream_req_body(MaxHunk, ReqState0),
     put(tmp_reqstate, ReqState),
     maybe_conflict_body(ReqResp).
 


### PR DESCRIPTION
OTP 20 is our only tested release that still supports it. We don't use this internally for anything other than wasting cycles constructing and destructing a `{webmachine_request, #wm_reqstate{}}` tuple. The bare `#wm_reqstate{}` record is good enough.

We'll have to drop OTP 20 if we decide to use the new logger subsystem, which was introduced in 21. Seems like a good excuse to get rid of this clutter.