### PR TITLE
webmachine_util: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/webmachine_util.erl
+++ b/src/webmachine_util.erl
@@ -264,15 +264,15 @@ do_choose(Choices, Header, Default) ->
     DefaultOkay = case DefaultPrio of
         [] ->
             case StarPrio of
-                [0.0] -> no;
+                [SP] when SP == 0.0 -> no;
                 _ -> yes
             end;
-        [0.0] -> no;
+        [DP] when DP == 0.0 -> no;
         _ -> yes
     end,
     AnyOkay = case StarPrio of
         [] -> no;
-        [0.0] -> no;
+        [SP2] when SP2 == 0.0 -> no;
         _ -> yes
     end,
     do_choose(Default, DefaultOkay, AnyOkay, Choices, Accepted).
@@ -296,7 +296,7 @@ do_choose(Default, DefaultOkay, AnyOkay, Choices, []) ->
 do_choose(Default, DefaultOkay, AnyOkay, Choices, [AccPair|AccRest]) ->
     {Prio, Acc} = AccPair,
     case Prio of
-        0.0 ->
+        _ when Prio == 0.0 ->
             do_choose(Default, DefaultOkay, AnyOkay,
                             lists:delete(Acc, Choices), AccRest);
         _ ->


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in webmachine results in:

===> Compiling src/webmachine_util.erl failed
src/webmachine_util.erl:267:18: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/webmachine_util.erl:270:10: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
src/webmachine_util.erl:275:10: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
@src/webmachine_util.erl:299:9: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from matches to numerical comparisons.