### PR TITLE
update mochiweb dep to get upstream 0.0 matching fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, "3.1.1", {git, "https://github.com/mochi/mochiweb.git", {tag, "v3.1.1"}}}]}.
+{deps, [{mochiweb, "3.2.1", {git, "https://github.com/mochi/mochiweb.git", {tag, "v3.2.1"}}}]}.
 
 {eunit_opts, [
               no_tty,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb.git",
-       {ref,"7c4d3110b1889a5d58eb4dda2b1ddbb5645df3e9"}},
+       {ref,"897f22f6720cf369547d1303888b46b5a00e00b4"}},
   0}].


### PR DESCRIPTION
mochi/mochiweb#260 is the same sort of fix as webmachine/webmachine#340 - updating floating point 0.0 matching for OTP 27 compatibility