### PR TITLE
update mochiweb dep to get upstream 'maybe' fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {xref_checks, [undefined_function_calls]}.
 
-{deps, [{mochiweb, "3.2.1", {git, "https://github.com/mochi/mochiweb.git", {tag, "v3.2.1"}}}]}.
+{deps, [{mochiweb, "3.2.2", {git, "https://github.com/mochi/mochiweb.git", {tag, "v3.2.2"}}}]}.
 
 {eunit_opts, [
               no_tty,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb.git",
-       {ref,"897f22f6720cf369547d1303888b46b5a00e00b4"}},
+       {ref,"611254eb941e502227f221667389b98fd8e72d6f"}},
   0}].


### PR DESCRIPTION
OTP 27 enables the new `maybe` keyword by default. Without setting compiler flags, a Webmachine project will fail to build with the compiler claiming that `{maybe, Start}` in mochiweb is a syntax error.