### PR TITLE
Version bump (for tagging 1.12.0)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 
 {profiles,
  [{test,
-   [{deps, [meck,
+   [{deps, [{meck, "0.9.2"},
             {ibrowse, "4.4.0"}
            ]},
     {erl_opts, [debug_info]}

--- a/src/webmachine_app.erl
+++ b/src/webmachine_app.erl
@@ -27,7 +27,7 @@
 
 -include("webmachine_logger.hrl").
 
--define(QUIP, "greased slide to failure").
+-define(QUIP, "Stuff just happened.").
 
 %% @spec start(_Type, _StartArgs) -> ServerRet
 %% @doc application start callback for webmachine.


### PR DESCRIPTION
As proposed in #347. I'll tag 1.12.0 after merge?