### PR TITLE
Fix maybe_flush_req_body/1 hang when body was eagerly read

### DIFF
--- a/src/webmachine_request.erl
+++ b/src/webmachine_request.erl
@@ -87,6 +87,12 @@
 
 -define(IDLE_TIMEOUT, infinity).
 
+%% Finite timeout used when we're only draining leftover request bytes
+%% (see maybe_flush_req_body/1). Kept intentionally short so that a
+%% misbehaving or already-drained peer can never wedge the request
+%% pipeline. Legitimate streaming reads still use ?IDLE_TIMEOUT.
+-define(FLUSH_TIMEOUT, 5000).
+
 -type t() :: #wm_reqstate{}.
 -export_type([t/0]).
 
@@ -588,7 +594,10 @@ expects_continue(PassedState) ->
 sent_continue() ->
     get(webmachine_sent_continue) =:= true.
 
-recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
+recv_stream_body(PassedState, MaxHunkSize) ->
+    recv_stream_body(PassedState, MaxHunkSize, ?IDLE_TIMEOUT).
+
+recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize, Timeout) ->
     case expects_continue(PassedState) and (not sent_continue()) of
         true ->
             put(webmachine_sent_continue, true),
@@ -608,28 +617,29 @@ recv_stream_body(PassedState=#wm_reqstate{reqdata=RD}, MaxHunkSize) ->
             {<<>>, done};
         chunked ->
             start_recv_chunked_body(PassedState#wm_reqstate.socket,
-                                    MaxHunkSize);
+                                    MaxHunkSize, Timeout);
         Length ->
             recv_unchunked_body(PassedState#wm_reqstate.socket,
-                                MaxHunkSize, Length)
+                                MaxHunkSize, Length, Timeout)
     end.
 
-recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
+recv_unchunked_body(Socket, MaxHunk, DataLeft, Timeout) ->
     case MaxHunk >= DataLeft of
         true ->
-            case mochiweb_socket:recv(Socket,DataLeft,?IDLE_TIMEOUT) of
-                {ok,Data1} ->
+            case mochiweb_socket:recv(Socket, DataLeft, Timeout) of
+                {ok, Data1} ->
                     record_stream_progress(done),
                     {Data1, done};
                 {error, Error} ->
                     throw({webmachine_recv_error, Error})
             end;
         false ->
-            case mochiweb_socket:recv(Socket,MaxHunk,?IDLE_TIMEOUT) of
-                {ok,Data2} ->
+            case mochiweb_socket:recv(Socket, MaxHunk, Timeout) of
+                {ok, Data2} ->
                     Next = fun() ->
                                    recv_unchunked_body(Socket, MaxHunk,
-                                                       DataLeft-MaxHunk)
+                                                       DataLeft - MaxHunk,
+                                                       Timeout)
                            end,
                     record_stream_progress(Next),
                     {Data2, Next};
@@ -638,21 +648,22 @@ recv_unchunked_body(Socket, MaxHunk, DataLeft) ->
             end
     end.
 
-start_recv_chunked_body(Socket, MaxHunk) ->
-    case read_chunk_length(Socket, false) of
+start_recv_chunked_body(Socket, MaxHunk, Timeout) ->
+    case read_chunk_length(Socket, false, Timeout) of
         0 ->
             record_stream_progress(done),
             {<<>>, done};
         ChunkLength ->
-            recv_chunked_body(Socket,MaxHunk, ChunkLength)
+            recv_chunked_body(Socket, MaxHunk, ChunkLength, Timeout)
     end.
-recv_chunked_body(Socket, MaxHunk, LeftInChunk) ->
+recv_chunked_body(Socket, MaxHunk, LeftInChunk, Timeout) ->
     case MaxHunk >= LeftInChunk of
         true ->
-            case mochiweb_socket:recv(Socket,LeftInChunk,?IDLE_TIMEOUT) of
-                {ok,Data1} ->
+            case mochiweb_socket:recv(Socket, LeftInChunk, Timeout) of
+                {ok, Data1} ->
                     Next = fun() ->
-                                   start_recv_chunked_body(Socket, MaxHunk)
+                                   start_recv_chunked_body(Socket, MaxHunk,
+                                                           Timeout)
                            end,
                     record_stream_progress(Next),
                     {Data1, Next};
@@ -660,11 +671,12 @@ recv_chunked_body(Socket, MaxHunk, LeftInChunk) ->
                     throw({webmachine_recv_error, Error})
             end;
         false ->
-            case mochiweb_socket:recv(Socket,MaxHunk,?IDLE_TIMEOUT) of
-                {ok,Data2} ->
+            case mochiweb_socket:recv(Socket, MaxHunk, Timeout) of
+                {ok, Data2} ->
                     Next = fun() ->
                                    recv_chunked_body(Socket, MaxHunk,
-                                                     LeftInChunk-MaxHunk)
+                                                     LeftInChunk - MaxHunk,
+                                                     Timeout)
                            end,
                     record_stream_progress(Next),
                     {Data2, Next};
@@ -673,9 +685,9 @@ recv_chunked_body(Socket, MaxHunk, LeftInChunk) ->
             end
     end.
 
-read_chunk_length(Socket, MaybeLastChunk) ->
+read_chunk_length(Socket, MaybeLastChunk, Timeout) ->
     mochiweb_socket:setopts(Socket, [{packet, line}]),
-    case mochiweb_socket:recv(Socket, 0, ?IDLE_TIMEOUT) of
+    case mochiweb_socket:recv(Socket, 0, Timeout) of
         {ok, Header} ->
             mochiweb_socket:setopts(Socket, [{packet, raw}]),
             Splitter = fun (C) ->
@@ -689,7 +701,7 @@ read_chunk_length(Socket, MaybeLastChunk) ->
                     %% allow [badly formed] last chunk header to be
                     %% empty instead of '0' explicitly
                     if MaybeLastChunk -> 0;
-                       true -> read_chunk_length(Socket, true)
+                       true -> read_chunk_length(Socket, true, Timeout)
                     end;
                 _ ->
                     erlang:list_to_integer(Hex, 16)
@@ -713,28 +725,34 @@ maybe_flush_req_body(Req) ->
             put(mochiweb_request_recv, true),
             true;
         undefined ->
-            case expects_continue(Req) and (not sent_continue()) of
+            case get(mochiweb_request_recv) of
                 true ->
-                    %% If the request expected continue, but we didn't
-                    %% send it, then tell mochiweb to ignore what the
-                    %% content length or transfer encoding says about
-                    %% a body.
-                    put(mochiweb_request_recv, true),
+                    %% The request body was already consumed via
+                    %% wrq:req_body/1 (eager read). mochiweb's
+                    %% request_recv flag is set but our own
+                    %% webmachine_stream_progress was never touched
+                    %% because the eager path bypasses
+                    %% recv_stream_body/2. There is nothing left on
+                    %% the socket to drain; attempting to recv here
+                    %% would block on an already-empty socket.
                     true;
-                false ->
-                    MaxFlush = max_flush_bytes(),
-                    case MaxFlush of
-                        0 ->
-                            %% this server has been configured to
-                            %% close connections on clients who send
-                            %% requests whose bodies are ignored
-                            false;
-                        _ ->
-                            %% There might be a body sitting out there we
-                            %% haven't read - give it a try.
-                            ReadSize = erlang:min(65535, MaxFlush),
-                            flush_req_body(
-                              catch recv_stream_body(Req, ReadSize), MaxFlush)
+                _ ->
+                    %% Cross-process-safe fallback: some
+                    %% applications dispatch body reads to a
+                    %% separate worker process, so the
+                    %% mochiweb_request_recv pdict flag never lands
+                    %% on the mochiweb loop process even though the
+                    %% body was consumed. The bodyfetch field is
+                    %% set to `standard` or `stream` inside
+                    %% call({req_body, MaxRecvBody}, ReqState) when
+                    %% the body is read, and travels with the
+                    %% ReqState by value across process boundaries
+                    %% (unlike the pdict). Consult it before
+                    %% falling into the drain path.
+                    case Req#wm_reqstate.bodyfetch of
+                        standard -> true;
+                        stream -> true;
+                        _ -> maybe_flush_undefined_drain(Req)
                     end
             end;
         Next ->
@@ -746,6 +764,39 @@ maybe_flush_req_body(Req) ->
                     %% request processing stopped in the middle of a stream -
                     %% can we finish it?
                     flush_req_body(catch Next(), MaxFlush)
+            end
+    end.
+
+%% Handles the "we have no idea whether a body is on the wire" branch
+%% of maybe_flush_req_body/1. Only reached when
+%% get(mochiweb_request_recv) is not `true` (i.e. no eager read has
+%% claimed the body), so an actual attempt to recv is warranted. The
+%% recv is bounded by ?FLUSH_TIMEOUT rather than ?IDLE_TIMEOUT so that
+%% a bogus content-length or a peer that closed without shutting down
+%% write cleanly cannot wedge the request pipeline.
+maybe_flush_undefined_drain(Req) ->
+    case expects_continue(Req) and (not sent_continue()) of
+        true ->
+            %% If the request expected continue, but we didn't send
+            %% it, then tell mochiweb to ignore what the content
+            %% length or transfer encoding says about a body.
+            put(mochiweb_request_recv, true),
+            true;
+        false ->
+            MaxFlush = max_flush_bytes(),
+            case MaxFlush of
+                0 ->
+                    %% this server has been configured to close
+                    %% connections on clients who send requests whose
+                    %% bodies are ignored
+                    false;
+                _ ->
+                    %% There might be a body sitting out there we
+                    %% haven't read - give it a bounded try.
+                    ReadSize = erlang:min(65535, MaxFlush),
+                    flush_req_body(
+                      catch recv_stream_body(Req, ReadSize, ?FLUSH_TIMEOUT),
+                      MaxFlush)
             end
     end.
 

--- a/test/flush_req_body_test.erl
+++ b/test/flush_req_body_test.erl
@@ -1,0 +1,196 @@
+%% Regression test for maybe_flush_req_body/1's cross-process fallback.
+%%
+%% Some downstream apps dispatch the eager body read
+%% (wrq:req_body/1) to a worker process. wrq:req_body/1 stashes an
+%% updated ReqState via `put(tmp_reqstate, NewReqState)` in the
+%% CALLER's process dictionary, and the underlying
+%% recv_stream_body/2 records
+%% `put(webmachine_stream_progress, done)` there too. When the caller
+%% is a worker (not the mochiweb loop process), the loop's pdict is
+%% left with neither flag, so maybe_flush_req_body/1's
+%% `get(webmachine_stream_progress)` returns `undefined` and — on the
+%% pre-fix code path — falls into a drain that recv's on an already-
+%% empty socket with ?IDLE_TIMEOUT = infinity, wedging the request.
+%%
+%% multi_request_connection_test masks this by pipelining a second
+%% request on the same socket: the drain finds the follow-up bytes
+%% already on the wire, tracks them against the first request's
+%% content-length, and returns quickly. Real clients (curl, most HTTP
+%% libraries) send one request and wait, hitting the hang.
+%%
+%% The fix adds a cross-process-safe guard: even when the loop's
+%% pdict is empty, `Req#wm_reqstate.bodyfetch` travels with the
+%% ReqState by value across process boundaries, and matching it
+%% against `standard`/`stream` short-circuits the drain.
+%%
+%% This test simulates the downstream pattern: worker spawns, reads
+%% the body, and returns its `tmp_reqstate` to the resource callback,
+%% which stores it in the loop's pdict — same as fe_api_base_resource
+%% does. Then a single-request-per-socket POST with a bounded recv
+%% timeout distinguishes "responded fast" (post-fix) from "hanging"
+%% (pre-fix).
+-module(flush_req_body_test).
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([
+         init/1,
+         allowed_methods/2,
+         content_types_provided/2,
+         content_types_accepted/2,
+         to_text/2,
+         process_post/2
+        ]).
+
+%% Bounded per-response wait. Without the fix the drain calls
+%% recv(..., ?IDLE_TIMEOUT = infinity) on an empty socket, so 3
+%% seconds is plenty to distinguish "responded fast" from "hanging".
+-define(RECV_TIMEOUT_MS, 3000).
+
+%%% TESTS
+
+flush_req_body_tests() ->
+    [
+     fun cross_process_eager_read_test/1
+    ].
+
+cross_process_eager_read_test(Ctx) ->
+    Resp = send_single_request(
+             Ctx,
+             "POST", "worker",
+             [{"content-type", "text/plain"}],
+             "flush me from a worker process"),
+    ?assertMatch({ok, "HTTP/1.1 204" ++ _, _, _}, Resp),
+    ok.
+
+%%% RESOURCE
+
+init([]) ->
+    {ok, undefined}.
+
+allowed_methods(RD, Ctx) ->
+    {['POST'], RD, Ctx}.
+
+%% Required by the decision core even for POST -> 204: the decision
+%% graph inspects the provided types on the way to picking a response
+%% renderer. Omitting this makes the resource crash to 500.
+content_types_provided(RD, Ctx) ->
+    {[{"text/plain", to_text}], RD, Ctx}.
+
+to_text(RD, Ctx) ->
+    {"", RD, Ctx}.
+
+%% For POST, webmachine calls process_post/2, so content_types_accepted
+%% just needs a callable to satisfy negotiation.
+content_types_accepted(RD, Ctx) ->
+    {[{"text/plain", process_post}], RD, Ctx}.
+
+%% Dispatch the eager read to a worker, then propagate the worker's
+%% tmp_reqstate back into the loop process's pdict so decision_core
+%% threads the updated ReqState (with bodyfetch = standard) into Req
+%% before maybe_flush_req_body/1 runs.
+process_post(RD, Ctx) ->
+    Parent = self(),
+    {WorkerPid, WorkerMon} = spawn_monitor(
+        fun() ->
+            _Body = wrq:req_body(RD),
+            %% wrq:req_body/1 sets tmp_reqstate in the caller's pdict.
+            %% Send it back to the parent so the parent can put it into
+            %% its own pdict; that's how the updated ReqState makes the
+            %% cross-process trip.
+            Parent ! {self(), tmp_reqstate, get(tmp_reqstate)},
+            ok
+        end),
+    receive
+        {WorkerPid, tmp_reqstate, WorkerReqState} ->
+            erlang:demonitor(WorkerMon, [flush]),
+            put(tmp_reqstate, WorkerReqState);
+        {'DOWN', WorkerMon, process, WorkerPid, Reason} ->
+            erlang:error({worker_died, Reason})
+    after 5000 ->
+        erlang:error(worker_timeout)
+    end,
+    {true, RD, Ctx}.
+
+%%% TEST SETUP
+
+flush_req_body_test_() ->
+    {foreach,
+     fun() ->
+             DL = [{[atom_to_list(?MODULE), '*'], ?MODULE, []}],
+             wm_integration_test_util:start(?MODULE, "0.0.0.0", DL)
+     end,
+     fun(Ctx) ->
+             wm_integration_test_util:stop(Ctx)
+     end,
+     [fun(Ctx) ->
+              {spawn, {with, Ctx, flush_req_body_tests()}}
+      end]}.
+
+%%% HTTP HELPERS (single-request-per-socket)
+
+%% NOTE: no `Connection: close`. webmachine short-circuits the
+%% flush-and-idle path on close-marked connections, so a close header
+%% would let a broken build "pass" this test.
+send_single_request(Ctx, Method, Path, Headers, Body) ->
+    Request = build_request(Method, Path, Headers, Body),
+    {ok, Sock} = gen_tcp:connect(
+                   "localhost",
+                   wm_integration_test_util:get_port(Ctx),
+                   [list, {active, false}]),
+    try
+        ok = gen_tcp:send(Sock, iolist_to_binary(Request)),
+        receive_response([], Sock)
+    after
+        gen_tcp:close(Sock)
+    end.
+
+build_request(Method, Path, Headers, Body) ->
+    ContentLength = integer_to_list(length(Body)),
+    ExtraHeaders = case Body of
+                       [] -> Headers;
+                       _  -> [{"content-length", ContentLength} | Headers]
+                   end,
+    [Method, " /", atom_to_list(?MODULE), "/", Path, " HTTP/1.1\r\n",
+     "Host: localhost\r\n",
+     [ [K, ": ", V, "\r\n"] || {K, V} <- ExtraHeaders ],
+     "\r\n",
+     Body].
+
+receive_response(Buffer, Sock) ->
+    case string:split(Buffer, "\r\n\r\n") of
+        [Head, RestAfterHead] ->
+            [Code | RawHeaders] = string:tokens(Head, "\r\n"),
+            Hdrs = [list_to_tuple(string:tokens(H, ": ")) || H <- RawHeaders],
+            BodyLen = case lists:keyfind("Content-Length", 1, Hdrs) of
+                          {_, LStr} -> list_to_integer(LStr);
+                          false     -> 0
+                      end,
+            BodyBytes = lists:flatten(RestAfterHead),
+            Body = case length(BodyBytes) >= BodyLen of
+                       true  -> lists:sublist(BodyBytes, BodyLen);
+                       false -> BodyBytes ++ recv_body(Sock,
+                                                       BodyLen -
+                                                       length(BodyBytes))
+                   end,
+            {ok, Code, Hdrs, Body};
+        _IncompleteHead ->
+            case gen_tcp:recv(Sock, 0, ?RECV_TIMEOUT_MS) of
+                {ok, Data} ->
+                    receive_response(Buffer ++ Data, Sock);
+                {error, _} = Error ->
+                    Error
+            end
+    end.
+
+recv_body(_Sock, 0) ->
+    [];
+recv_body(Sock, Remaining) when Remaining > 0 ->
+    case gen_tcp:recv(Sock, Remaining, ?RECV_TIMEOUT_MS) of
+        {ok, Data} -> Data ++ recv_body(Sock, Remaining - length(Data));
+        {error, _} -> []
+    end.
+
+-endif.


### PR DESCRIPTION
## Summary

Fixes a POST/PUT-request hang introduced in 1.12 where the new
`wrcall(maybe_flush_req_body)` step in
`webmachine_decision_core:finish_response/2` unconditionally attempts to
drain the socket with an infinite recv timeout, even when the request
body was already fully consumed via `wrq:req_body/1`.

## Root cause

`maybe_flush_req_body/1` was introduced in 1.12 to drain any request-body
bytes still on the socket before `send_response` runs. Its `undefined`
branch of `get_stream_progress/0` unconditionally called `recv_stream_body`
with `?IDLE_TIMEOUT = infinity`, which is unsafe in three ways:

1. Resources that read the request body eagerly (`wrq:req_body/1`) set
   `mochiweb_request_recv` but never touch `webmachine_stream_progress`.
   `maybe_flush_req_body` sees `undefined`, attempts to drain, and blocks
   forever on an already-empty socket. The request completes on the
   server side but the response is never written and the client hangs
   until its own timeout. This regresses correctness for every resource
   that uses the eager-read path.

2. Applications that dispatch body reads to a separate worker process
   (a common pattern for offloading long-running work) get
   `mochiweb_request_recv` set on the worker's pdict rather than on
   the mochiweb loop process that runs `maybe_flush_req_body/1`. The
   loop process still sees `undefined` for both `webmachine_stream_progress`
   and `mochiweb_request_recv` and falls into the drain path even though
   the body was fully consumed.

3. Even for resources that legitimately reach the drain path, using
   `?IDLE_TIMEOUT = infinity` for a fallback flush is a footgun: a
   misbehaving client that half-closes the write side and sends a
   Content-Length header but no body wedges the request pipeline
   indefinitely.

## Fix

Three defenses, in priority order:

* **Fast path (pdict guard).** Guard the `undefined` branch on
  `get(mochiweb_request_recv) =:= true` and return `true` immediately in
  that case. Eager reads mark the request as recv'd; there's nothing
  left on the socket to drain.

* **Cross-process fallback (ReqState guard).** When the pdict flag is
  not set, consult `Req#wm_reqstate.bodyfetch`. `bodyfetch` is set to
  `standard` or `stream` inside `call({req_body, ...}, ReqState)` in
  the same call path that would set the pdict flag, and unlike the
  pdict it travels with the `ReqState` value across process boundaries.
  Applications that thread the updated `ReqState` back to the mochiweb
  loop process (via the returned `Request#wm_reqdata.wm_state` field)
  will hit this fallback and short-circuit the drain.

* **Safety net (`?FLUSH_TIMEOUT`).** When neither signal is set, still
  attempt to drain, but with `?FLUSH_TIMEOUT = 5000` instead of
  `?IDLE_TIMEOUT = infinity`. Threaded through a new
  `recv_stream_body/3` variant used only by `maybe_flush_undefined_drain/1`.
  Legitimate streaming callers (`stream_req_body`, `do_recv_body`) still
  get `?IDLE_TIMEOUT = infinity` via the 2-arg wrapper.

## Test evidence

Reproduced against OTP 26.2.5 in a downstream application. A large
POST/PUT eunit suite hung indefinitely on 1.12.0 for every resource
that used `wrq:req_body/1`. After the patch, target-class cases pass.
For a further subset that used a cross-process worker pattern, the
`?FLUSH_TIMEOUT` safety net converted the infinite hang into a 5s
per-request delay; the additional `bodyfetch` fallback resolves those
by consulting `ReqState` in addition to the pdict.

Compact dbg trace showing the original hang shape:

```
18:31:58.164 maybe_flush_req_body ENTRY progress=undefined
18:31:58.164 maybe_flush_req_body branch=undefined expects_continue=false
18:31:58.164 maybe_flush_req_body undefined->drain max_flush=67108864
18:31:58.164 maybe_flush_req_body BEFORE recv_stream_body read_size=65535
18:31:58.164 mochiweb_socket:recv ENTRY sock=tcp length=21 timeout=infinity
18:32:02.302 [context murdered by client timeout, no AFTER log]
```

## Compatibility

Additive — no existing callers of `recv_stream_body/2` change semantics.
A new `recv_stream_body/3` variant is added for the finite-timeout
fallback path. Legitimate streaming reads (`stream_req_body`,
`do_recv_body`) still use `?IDLE_TIMEOUT = infinity`. The new `bodyfetch`
guard is a pure lookup on an existing `#wm_reqstate{}` field; no new
fields introduced, no message-shape changes.
