### PR TITLE
drop testing of OTP versions 20-23

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        otp_version: [25, 24]
+        otp_version: [28, 27, 26, 25, 24]
         rebar3_version: ["3.20"]
         os: ["ubuntu-latest"]
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,8 +7,19 @@ jobs:
     strategy:
       matrix:
         otp_version: [28, 27, 26, 25, 24]
-        rebar3_version: ["3.20"]
         os: ["ubuntu-latest"]
+        include:
+          - otp_version: 28
+            rebar3_version: "3.25.1"
+          - otp_version: 27
+            rebar3_version: "3.25.1"
+          - otp_version: 26
+            rebar3_version: "3.25.1"
+          - otp_version: 25
+            rebar3_version: "3.24"
+          - otp_version: 24
+            rebar3_version: "3.21"
+
       fail-fast: false
       max-parallel: 2
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: "OTP${{ matrix.otp_version}}, rebar3 v${{ matrix.rebar3_version }}"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.otp_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,19 +9,6 @@ jobs:
         otp_version: [25, 24]
         rebar3_version: ["3.20"]
         os: ["ubuntu-latest"]
-        include:
-          - otp_version: 23
-            rebar3_version: "3.20"
-            os: "ubuntu-20.04"
-          - otp_version: 22
-            rebar3_version: "3.16"
-            os: "ubuntu-20.04"
-          - otp_version: 21
-            rebar3_version: "3.15"
-            os: "ubuntu-20.04"
-          - otp_version: 20
-            rebar3_version: "3.15"
-            os: "ubuntu-20.04"
       fail-fast: false
       max-parallel: 2
 


### PR DESCRIPTION
Their github actions requested ubuntu 20.04 images, which standard runners no longer support. OTP 23 is six years old, so I think it's safe to move on.

I think I remember last time we updated this file, we had to push directly to main, instead of going this route, because github actions will pick up the old build-test.yaml to test the new branch. But let's see what happens.